### PR TITLE
Remove empty line in F3+H tooltip

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/core/handlers/ClientEventHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/core/handlers/ClientEventHandler.java
@@ -230,7 +230,6 @@ public class ClientEventHandler {
 	@SubscribeEvent
 	public void toolTipEvent(ItemTooltipEvent event) {
 		if(ConfigBase.enableExtraF3HTooltips && event.showAdvancedItemTooltips) {
-			event.toolTip.add("");
 			event.toolTip.add("\u00a78" + Item.itemRegistry.getNameForObject(event.itemStack.getItem()));
 			if(event.itemStack.stackTagCompound != null && !event.itemStack.stackTagCompound.hasNoTags())
 				event.toolTip.add("\u00a78NBT: " + event.itemStack.stackTagCompound.func_150296_c().size() + " Tag(s)");


### PR DESCRIPTION
For some reason there's an empty line in the F3+H tooltip, even though there's none on e.g. 1.12.2.

Et Futurum now *+ WAILA*:
![xnview_2021-07-24_00-04-07](https://user-images.githubusercontent.com/13667520/126845797-eee80d4b-96c9-4d64-84a9-ada5dc330490.png)
Vanilla 1.12.2:
![xnview_2021-07-24_00-04-56](https://user-images.githubusercontent.com/13667520/126845841-3b9cef5f-fe86-422e-918b-c1231ed9af64.png)

This PR removes the empty line.