### PR TITLE
Fix crash when opening stats window

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -17,6 +17,7 @@ import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLModIdMappingEvent;
 import cpw.mods.fml.common.event.FMLInterModComms.IMCEvent;
 import cpw.mods.fml.common.event.FMLInterModComms.IMCMessage;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -68,6 +69,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.stats.StatCrafting;
+import net.minecraft.stats.StatList;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.common.BiomeDictionary;
@@ -310,6 +313,12 @@ public class EtFuturum {
 	public void serverStarting(FMLServerStartingEvent event) {
 //        if (ConfigurationHandler.enablePlayerSkinOverlay)
 //            event.registerServerCommand(new SetPlayerModelCommand());
+	}
+	
+	@EventHandler
+	public void idMappingEvent(FMLModIdMappingEvent event) {
+		// update end portal reference in StatList
+		ReflectionHelper.setPrivateValue(StatCrafting.class, (StatCrafting)StatList.mineBlockStatArray[119], Item.getItemFromBlock(Block.getBlockById(119)), "field_150960_a");
 	}
 	
 	public static void copyAttribs(Block to, Block from) {


### PR DESCRIPTION
The new end portal block made the game crash when the stats window is opened.

```
java.lang.ArrayIndexOutOfBoundsException: -1
	at net.minecraft.client.gui.achievement.GuiStats$StatsBlock.<init>(SourceFile:548)
	at net.minecraft.client.gui.achievement.GuiStats.func_146509_g(SourceFile:123)
	at net.minecraft.client.network.NetHandlerPlayClient.func_147293_a(NetHandlerPlayClient.java:1328)
	at net.minecraft.network.play.server.S37PacketStatistics.func_148833_a(SourceFile:26)
	...
```
This was because there was a stale reference to the old end portal block in `StatList.objectMineStats` (backed by `StatList.mineBlockStatArray`). When the game tried to resolve its id, it got -1, which it then tried to use as an index into`StatList.objectUseStats`, hence the exception.
I fixed that by updating the stale reference to the new block.

Now there's no crash and the stats are updated correctly when you place or break end portal blocks.