### PR TITLE
Refactor (de)serialization of ItemStack lists to use a helper function

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockShulkerBox.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockShulkerBox.java
@@ -76,17 +76,7 @@ public class BlockShulkerBox extends BlockContainer implements IConfigurable, IS
 		if(stack.hasTagCompound()) {
 			NBTTagList nbttaglist = stack.getTagCompound().getTagList("Items", 10);
 			box.chestContents = new ItemStack[box.getSizeInventory()];
-
-			for (int i = 0; i < nbttaglist.tagCount(); ++i)
-			{
-				NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
-				int j = nbttagcompound1.getByte("Slot") & 255;
-
-				if (j >= 0 && j < box.chestContents.length)
-				{
-					box.chestContents[j] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
-				}
-			}
+			Utils.loadItemStacksFromNBT(nbttaglist, box.chestContents);
 			
 			if(stack.getTagCompound().hasKey("Color")) {
 				box.color = stack.getTagCompound().getByte("Color");

--- a/src/main/java/ganymedes01/etfuturum/core/utils/Utils.java
+++ b/src/main/java/ganymedes01/etfuturum/core/utils/Utils.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import ganymedes01.etfuturum.lib.Reference;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.IBlockAccess;
@@ -45,6 +48,35 @@ public class Utils {
 		for (int id : OreDictionary.getOreIDs(stack))
 			list.add(OreDictionary.getOreName(id));
 
+		return list;
+	}
+
+	public static void loadItemStacksFromNBT(NBTTagList tag, ItemStack[] stacks) {
+		for (int i = 0; i < tag.tagCount(); ++i)
+		{
+			NBTTagCompound nbttagcompound1 = tag.getCompoundTagAt(i);
+			int j = nbttagcompound1.getByte("Slot") & 255;
+
+			if (j >= 0 && j < stacks.length)
+			{
+				stacks[j] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
+			}
+		}
+	}
+
+	public static NBTTagList writeItemStacksToNBT(ItemStack[] stacks) {
+		NBTTagList list = new NBTTagList();
+
+		for (int i = 0; i < stacks.length; ++i)
+		{
+			if (stacks[i] != null)
+			{
+				NBTTagCompound tag = new NBTTagCompound();
+				tag.setByte("Slot", (byte)i);
+				stacks[i].writeToNBT(tag);
+				list.appendTag(tag);
+			}
+		}
 		return list;
 	}
 }

--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBarrel.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBarrel.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import ganymedes01.etfuturum.blocks.BlockBarrel;
+import ganymedes01.etfuturum.core.utils.Utils;
 import ganymedes01.etfuturum.lib.Reference;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ContainerChest;
@@ -40,17 +41,7 @@ public class TileEntityBarrel extends TileEntity implements IInventory {
 		super.readFromNBT(p_145839_1_);
 		NBTTagList nbttaglist = p_145839_1_.getTagList("Items", 10);
 		this.chestContents = new ItemStack[this.getSizeInventory()];
-
-		for (int i = 0; i < nbttaglist.tagCount(); ++i)
-		{
-			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
-			int j = nbttagcompound1.getByte("Slot") & 255;
-
-			if (j >= 0 && j < this.chestContents.length)
-			{
-				this.chestContents[j] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
-			}
-		}
+		Utils.loadItemStacksFromNBT(nbttaglist, this.chestContents);
 
 		if (p_145839_1_.hasKey("CustomName", 8))
 		{
@@ -62,20 +53,8 @@ public class TileEntityBarrel extends TileEntity implements IInventory {
 	public void writeToNBT(NBTTagCompound p_145841_1_)
 	{
 		super.writeToNBT(p_145841_1_);
-		NBTTagList nbttaglist = new NBTTagList();
-
-		for (int i = 0; i < this.chestContents.length; ++i)
-		{
-			if (this.chestContents[i] != null)
-			{
-				NBTTagCompound nbttagcompound1 = new NBTTagCompound();
-				nbttagcompound1.setByte("Slot", (byte)i);
-				this.chestContents[i].writeToNBT(nbttagcompound1);
-				nbttaglist.appendTag(nbttagcompound1);
-			}
-		}
-
-		p_145841_1_.setTag("Items", nbttaglist);
+		
+		p_145841_1_.setTag("Items", Utils.writeItemStacksToNBT(this.chestContents));
 
 		if (this.hasCustomInventoryName())
 		{

--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBlastFurnace.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBlastFurnace.java
@@ -3,6 +3,7 @@ package ganymedes01.etfuturum.tileentities;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.blocks.BlockBlastFurnace;
+import ganymedes01.etfuturum.core.utils.Utils;
 import ganymedes01.etfuturum.lib.Reference;
 import ganymedes01.etfuturum.recipes.BlastFurnaceRecipes;
 import net.minecraft.entity.player.EntityPlayer;
@@ -135,17 +136,7 @@ public class TileEntityBlastFurnace extends TileEntity implements ISidedInventor
 		super.readFromNBT(p_145839_1_);
 		NBTTagList nbttaglist = p_145839_1_.getTagList("Items", 10);
 		this.furnaceItemStacks = new ItemStack[this.getSizeInventory()];
-
-		for (int i = 0; i < nbttaglist.tagCount(); ++i)
-		{
-			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
-			byte b0 = nbttagcompound1.getByte("Slot");
-
-			if (b0 >= 0 && b0 < this.furnaceItemStacks.length)
-			{
-				this.furnaceItemStacks[b0] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
-			}
-		}
+		Utils.loadItemStacksFromNBT(nbttaglist, this.furnaceItemStacks);
 
 		this.furnaceBurnTime = p_145839_1_.getShort("BurnTime");
 		this.furnaceCookTime = p_145839_1_.getShort("CookTime");
@@ -163,20 +154,8 @@ public class TileEntityBlastFurnace extends TileEntity implements ISidedInventor
 		super.writeToNBT(p_145841_1_);
 		p_145841_1_.setShort("BurnTime", (short)this.furnaceBurnTime);
 		p_145841_1_.setShort("CookTime", (short)this.furnaceCookTime);
-		NBTTagList nbttaglist = new NBTTagList();
 
-		for (int i = 0; i < this.furnaceItemStacks.length; ++i)
-		{
-			if (this.furnaceItemStacks[i] != null)
-			{
-				NBTTagCompound nbttagcompound1 = new NBTTagCompound();
-				nbttagcompound1.setByte("Slot", (byte)i);
-				this.furnaceItemStacks[i].writeToNBT(nbttagcompound1);
-				nbttaglist.appendTag(nbttagcompound1);
-			}
-		}
-
-		p_145841_1_.setTag("Items", nbttaglist);
+		p_145841_1_.setTag("Items", Utils.writeItemStacksToNBT(this.furnaceItemStacks));
 
 		if (this.hasCustomInventoryName())
 		{

--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityNewBrewingStand.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityNewBrewingStand.java
@@ -5,6 +5,7 @@ import java.util.List;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.ModItems;
+import ganymedes01.etfuturum.core.utils.Utils;
 import ganymedes01.etfuturum.lib.Reference;
 import ganymedes01.etfuturum.recipes.BrewingFuelRegistry;
 import net.minecraft.entity.item.EntityItem;
@@ -171,14 +172,7 @@ public class TileEntityNewBrewingStand extends TileEntityBrewingStand {
 		super.readFromNBT(nbt);
 		NBTTagList nbttaglist = nbt.getTagList("Items", 10);
 		inventory = new ItemStack[getSizeInventory()];
-
-		for (int i = 0; i < nbttaglist.tagCount(); i++) {
-			NBTTagCompound nbt1 = nbttaglist.getCompoundTagAt(i);
-			byte b0 = nbt1.getByte("Slot");
-
-			if (b0 >= 0 && b0 < inventory.length)
-				inventory[b0] = ItemStack.loadItemStackFromNBT(nbt1);
-		}
+		Utils.loadItemStacksFromNBT(nbttaglist, inventory);
 
 		brewTime = nbt.getShort("BrewTime");
 
@@ -196,17 +190,8 @@ public class TileEntityNewBrewingStand extends TileEntityBrewingStand {
 	public void writeToNBT(NBTTagCompound nbt) {
 		super.writeToNBT(nbt);
 		nbt.setShort("BrewTime", (short) brewTime);
-		NBTTagList nbttaglist = new NBTTagList();
 
-		for (int i = 0; i < inventory.length; i++)
-			if (inventory[i] != null) {
-				NBTTagCompound nbt1 = new NBTTagCompound();
-				nbt1.setByte("Slot", (byte) i);
-				inventory[i].writeToNBT(nbt1);
-				nbttaglist.appendTag(nbt1);
-			}
-
-		nbt.setTag("Items", nbttaglist);
+		nbt.setTag("Items", Utils.writeItemStacksToNBT(inventory));
 
 		nbt.setInteger("Fuel", fuel);
 		nbt.setInteger("CurrentFuel", currentFuel);

--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityShulkerBox.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityShulkerBox.java
@@ -12,6 +12,7 @@ import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.blocks.BlockShulkerBox;
 import ganymedes01.etfuturum.configuration.ConfigBase;
 import ganymedes01.etfuturum.configuration.configs.ConfigBlocksItems;
+import ganymedes01.etfuturum.core.utils.Utils;
 import ganymedes01.etfuturum.inventory.ContainerShulkerBox;
 import ganymedes01.etfuturum.items.block.ItemShulkerBox;
 import ganymedes01.etfuturum.lib.Reference;
@@ -82,17 +83,7 @@ public class TileEntityShulkerBox extends TileEntity implements IInventory {
 		NBTTagList nbttaglist = nbt.getTagList("Items", 10);
 		if(nbttaglist.tagCount() > 0)
 		this.chestContents = new ItemStack[this.getSizeInventory()];
-
-		for (int i = 0; i < nbttaglist.tagCount(); ++i)
-		{
-			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
-			int j = nbttagcompound1.getByte("Slot") & 255;
-
-			if (j >= 0 && j < this.chestContents.length)
-			{
-				this.chestContents[j] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
-			}
-		}
+		Utils.loadItemStacksFromNBT(nbttaglist, this.chestContents);
 		
 		if(type.getIsClear()) {
 			NBTTagList displaynbt = nbt.getTagList("Display", 10);
@@ -128,21 +119,8 @@ public class TileEntityShulkerBox extends TileEntity implements IInventory {
 	public void writeToNBT(NBTTagCompound nbt)
 	{
 		super.writeToNBT(nbt);
-		NBTTagList nbttaglist = new NBTTagList();
 
-		for (int i = 0; i < this.chestContents.length; ++i)
-		{
-			if (this.chestContents[i] != null)
-			{
-				NBTTagCompound nbttagcompound1 = new NBTTagCompound();
-				nbttagcompound1.setByte("Slot", (byte)i);
-				this.chestContents[i].writeToNBT(nbttagcompound1);
-				nbttaglist.appendTag(nbttagcompound1);
-			}
-		}
-
-		nbt.setTag("Items", nbttaglist);
-		
+		nbt.setTag("Items", Utils.writeItemStacksToNBT(this.chestContents));
 		if(color > 0) {
 			nbt.setByte("Color", color);
 		}

--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntitySmoker.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntitySmoker.java
@@ -3,6 +3,7 @@ package ganymedes01.etfuturum.tileentities;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.blocks.BlockSmoker;
+import ganymedes01.etfuturum.core.utils.Utils;
 import ganymedes01.etfuturum.lib.Reference;
 import ganymedes01.etfuturum.recipes.SmokerRecipes;
 import net.minecraft.entity.player.EntityPlayer;
@@ -141,17 +142,7 @@ public class TileEntitySmoker extends TileEntity implements ISidedInventory
 		super.readFromNBT(p_145839_1_);
 		NBTTagList nbttaglist = p_145839_1_.getTagList("Items", 10);
 		this.furnaceItemStacks = new ItemStack[this.getSizeInventory()];
-
-		for (int i = 0; i < nbttaglist.tagCount(); ++i)
-		{
-			NBTTagCompound nbttagcompound1 = nbttaglist.getCompoundTagAt(i);
-			byte b0 = nbttagcompound1.getByte("Slot");
-
-			if (b0 >= 0 && b0 < this.furnaceItemStacks.length)
-			{
-				this.furnaceItemStacks[b0] = ItemStack.loadItemStackFromNBT(nbttagcompound1);
-			}
-		}
+		Utils.loadItemStacksFromNBT(nbttaglist, this.furnaceItemStacks);
 
 		this.furnaceBurnTime = p_145839_1_.getShort("BurnTime");
 		this.furnaceCookTime = p_145839_1_.getShort("CookTime");
@@ -169,20 +160,8 @@ public class TileEntitySmoker extends TileEntity implements ISidedInventory
 		super.writeToNBT(p_145841_1_);
 		p_145841_1_.setShort("BurnTime", (short)this.furnaceBurnTime);
 		p_145841_1_.setShort("CookTime", (short)this.furnaceCookTime);
-		NBTTagList nbttaglist = new NBTTagList();
 
-		for (int i = 0; i < this.furnaceItemStacks.length; ++i)
-		{
-			if (this.furnaceItemStacks[i] != null)
-			{
-				NBTTagCompound nbttagcompound1 = new NBTTagCompound();
-				nbttagcompound1.setByte("Slot", (byte)i);
-				this.furnaceItemStacks[i].writeToNBT(nbttagcompound1);
-				nbttaglist.appendTag(nbttagcompound1);
-			}
-		}
-
-		p_145841_1_.setTag("Items", nbttaglist);
+		p_145841_1_.setTag("Items", Utils.writeItemStacksToNBT(this.furnaceItemStacks));
 
 		if (this.hasCustomInventoryName())
 		{


### PR DESCRIPTION
Almost forgot I had this on my computer. Back when I was implementing bundles in my [own mod](https://github.com/makamys/DMod), I considered implementing it in Et Futurum at first, and did this refactor as preparation. It moves the item stack list (de)serialization code that's duplicated in numerous places to a helper function, cleaning up the code a little.