### PR TITLE
Send sync packet to client when levitation effect is applied

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/entities/EntityShulkerBullet.java
+++ b/src/main/java/ganymedes01/etfuturum/entities/EntityShulkerBullet.java
@@ -15,7 +15,9 @@ import ganymedes01.etfuturum.potion.EtFuturumPotions;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.play.server.S1DPacketEntityEffect;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EntityDamageSourceIndirect;
 import net.minecraft.util.EnumFacing;
@@ -451,7 +453,9 @@ public class EntityShulkerBullet extends Entity
 
                 if (result.entityHit instanceof EntityLivingBase)
                 {
-                    ((EntityLivingBase)result.entityHit).addPotionEffect(new PotionEffect(EtFuturumPotions.levitation.getId(), 10 * 20));
+                    PotionEffect effect = new PotionEffect(EtFuturumPotions.levitation.getId(), 10 * 20);
+                    ((EntityLivingBase)result.entityHit).addPotionEffect(effect);
+                    MinecraftServer.getServer().getConfigurationManager().sendPacketToAllPlayers(new S1DPacketEntityEffect(result.entityHit.getEntityId(), effect));
                 }
             }
         }


### PR DESCRIPTION
Fixes jitter.

Might be poorly optimized for bandwidth since the packet is sent to all players. Ideally it shouldn't be sent to players who don't have the entity loaded, but I don't know when it's safe to assume this is true for a player, so I played it safe.