### PR TITLE
Boat improvements

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import ganymedes01.etfuturum.network.*;
 import org.apache.commons.lang3.ArrayUtils;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 
@@ -50,12 +51,6 @@ import ganymedes01.etfuturum.core.utils.RawOreRegistry;
 import ganymedes01.etfuturum.core.utils.StrippedLogRegistry;
 import ganymedes01.etfuturum.entities.ModEntityList;
 import ganymedes01.etfuturum.lib.Reference;
-import ganymedes01.etfuturum.network.ArmourStandInteractHandler;
-import ganymedes01.etfuturum.network.ArmourStandInteractMessage;
-import ganymedes01.etfuturum.network.BlackHeartParticlesHandler;
-import ganymedes01.etfuturum.network.BlackHeartParticlesMessage;
-import ganymedes01.etfuturum.network.WoodSignOpenHandler;
-import ganymedes01.etfuturum.network.WoodSignOpenMessage;
 import ganymedes01.etfuturum.potion.ModPotions;
 import ganymedes01.etfuturum.recipes.BlastFurnaceRecipes;
 import ganymedes01.etfuturum.recipes.ModRecipes;
@@ -366,7 +361,8 @@ public class EtFuturum {
 		networkWrapper = NetworkRegistry.INSTANCE.newSimpleChannel(Reference.MOD_ID);
 		networkWrapper.registerMessage(ArmourStandInteractHandler.class, ArmourStandInteractMessage.class, 0, Side.SERVER);
 		networkWrapper.registerMessage(BlackHeartParticlesHandler.class, BlackHeartParticlesMessage.class, 1, Side.CLIENT);
-		networkWrapper.registerMessage(WoodSignOpenHandler.class, WoodSignOpenMessage.class, 3, Side.CLIENT);   
+		networkWrapper.registerMessage(WoodSignOpenHandler.class, WoodSignOpenMessage.class, 3, Side.CLIENT);
+		networkWrapper.registerMessage(BoatMoveHandler.class, BoatMoveMessage.class, 4, Side.SERVER);
 		{
 			if (Loader.isModLoaded("netherlicious")) {
 				File file = new File(event.getModConfigurationDirectory() + "/Netherlicious/Biome_Sound_Configuration.cfg");

--- a/src/main/java/ganymedes01/etfuturum/entities/EntityNewBoat.java
+++ b/src/main/java/ganymedes01/etfuturum/entities/EntityNewBoat.java
@@ -7,9 +7,11 @@ import com.google.common.collect.Lists;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import ganymedes01.etfuturum.EtFuturum;
 import ganymedes01.etfuturum.ModItems;
 import ganymedes01.etfuturum.configuration.configs.ConfigBlocksItems;
 import ganymedes01.etfuturum.lib.Reference;
+import ganymedes01.etfuturum.network.BoatMoveMessage;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.material.Material;
@@ -349,23 +351,6 @@ public class EntityNewBoat extends Entity {
 		boolean steer = canPassengerSteer();
 		boolean isThisDriver = getControllingPassenger() instanceof EntityClientPlayerMP;
 		boatYaw = yaw;
-		if(steer && isBoatDesynchedXY(x, y, z, yaw, pitch, isThisDriver ? 0.4D : 0.2D)) {
-			setPosition(x, y, z);
-			setRotation(yaw, pitch);
-			for(EntityLivingBase passenger : getPassengers()) {
-				passenger.rotationYaw += rotationYaw - prevRotationYaw;
-			}
-		}
-	}
-	
-	private boolean isBoatDesynchedXY(double x, double y, double z, float yaw, float pitch, double offset) {
-		if(Math.abs(posX - x) > offset) {
-			return true;
-		}
-		if(Math.abs(posZ - z) > offset) {
-			return true;
-		}
-		return false;
 	}
 
 	/**
@@ -518,6 +503,10 @@ public class EntityNewBoat extends Entity {
 					}
 				}
 			}
+		}
+
+		if(this.worldObj.isRemote && canPassengerSteer() && getControllingPassenger() instanceof EntityClientPlayerMP) {
+			EtFuturum.networkWrapper.sendToServer(new BoatMoveMessage(this));
 		}
 	}
 	

--- a/src/main/java/ganymedes01/etfuturum/entities/EntityNewBoat.java
+++ b/src/main/java/ganymedes01/etfuturum/entities/EntityNewBoat.java
@@ -392,6 +392,35 @@ public class EntityNewBoat extends Entity {
 			sitEntity(getSeat().riddenByEntity);
 		}
 	}
+
+	private void collideWithSurfaceBlocks() {
+		AxisAlignedBB box = this.boundingBox;
+		int minX = MathHelper.floor_double(box.minX - 0.2d);
+		int minY = MathHelper.floor_double(box.minY - 0.2d);
+		int minZ = MathHelper.floor_double(box.minZ - 0.2d);
+		int maxX = MathHelper.floor_double(box.maxX + 0.2d);
+		int maxY = MathHelper.floor_double(box.maxY + 0.2d);
+		int maxZ = MathHelper.floor_double(box.maxZ + 0.2d);
+
+		for(int x = minX; x <= maxX; x++) {
+			for(int y = minY; y <= maxY; y++) {
+				for(int z = minZ; z <= maxZ; z++) {
+					Block block = this.worldObj.getBlock(x, y, z);
+
+					if (block == Blocks.snow_layer)
+					{
+						this.worldObj.setBlockToAir(x, y, z);
+						this.isCollidedHorizontally = false;
+					}
+					else if (block == Blocks.waterlily)
+					{
+						this.worldObj.func_147480_a(x, y, z, true);
+						this.isCollidedHorizontally = false;
+					}
+				}
+			}
+		}
+	}
 	
 	/**
 	 * Called to update the entity's position/logic.
@@ -433,6 +462,7 @@ public class EntityNewBoat extends Entity {
 		
 		if (this.canPassengerSteer())
 		{
+			this.collideWithSurfaceBlocks();
 			if (this.getPassengers().size() == 0)
 			{
 				this.setPaddleState(false, false);

--- a/src/main/java/ganymedes01/etfuturum/entities/EntityNewBoat.java
+++ b/src/main/java/ganymedes01/etfuturum/entities/EntityNewBoat.java
@@ -348,8 +348,6 @@ public class EntityNewBoat extends Entity {
 		this.lerpZ = z;
 		this.lerpXRot = (double)pitch;
 		this.lerpSteps = 5;
-		boolean steer = canPassengerSteer();
-		boolean isThisDriver = getControllingPassenger() instanceof EntityClientPlayerMP;
 		boatYaw = yaw;
 	}
 

--- a/src/main/java/ganymedes01/etfuturum/network/BoatMoveHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/network/BoatMoveHandler.java
@@ -1,0 +1,39 @@
+package ganymedes01.etfuturum.network;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import net.minecraft.entity.Entity;
+import net.minecraft.network.play.server.S18PacketEntityTeleport;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+
+public class BoatMoveHandler implements IMessageHandler<BoatMoveMessage, IMessage> {
+    @Override
+    public IMessage onMessage(BoatMoveMessage message, MessageContext ctx) {
+        WorldServer vehWorld = DimensionManager.getWorld(message.dimensionId);
+        if(vehWorld != null) {
+            Entity vehicle = vehWorld.getEntityByID(message.entityId);
+            if(vehicle.riddenByEntity != ctx.getServerHandler().playerEntity) {
+                /* Only take position updates from the riding player */
+                return null;
+            }
+            double expectedDelta = vehicle.motionX * vehicle.motionX + vehicle.motionY * vehicle.motionY + vehicle.motionZ * vehicle.motionZ;
+            double deltaX = message.x - vehicle.posX;
+            double deltaY = message.y - vehicle.posY;
+            double deltaZ = message.z - vehicle.posZ;
+            double actualDelta = deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ;
+            MinecraftServer server = MinecraftServer.getServer();
+            if(Math.abs(expectedDelta - actualDelta) > 100.0D && !server.isSinglePlayer()) {
+                System.err.println("Vehicle moved wrongly");
+                vehicle.setPositionAndRotation(vehicle.posX - 1, vehicle.posY, vehicle.posZ - 1, vehicle.rotationYaw, vehicle.rotationPitch);
+                ctx.getServerHandler().sendPacket(new S18PacketEntityTeleport(vehicle));
+                return null;
+            }
+            vehicle.setPositionAndRotation(message.x, message.y, message.z, message.yaw, message.pitch);
+            ctx.getServerHandler().sendPacket(new S18PacketEntityTeleport(vehicle));
+        }
+        return null;
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/network/BoatMoveHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/network/BoatMoveHandler.java
@@ -15,6 +15,8 @@ public class BoatMoveHandler implements IMessageHandler<BoatMoveMessage, IMessag
         WorldServer vehWorld = DimensionManager.getWorld(message.dimensionId);
         if(vehWorld != null) {
             Entity vehicle = vehWorld.getEntityByID(message.entityId);
+            if(vehicle == null)
+                return null;
             if(vehicle.riddenByEntity != ctx.getServerHandler().playerEntity) {
                 /* Only take position updates from the riding player */
                 return null;

--- a/src/main/java/ganymedes01/etfuturum/network/BoatMoveMessage.java
+++ b/src/main/java/ganymedes01/etfuturum/network/BoatMoveMessage.java
@@ -1,0 +1,51 @@
+package ganymedes01.etfuturum.network;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.Entity;
+
+public class BoatMoveMessage implements IMessage {
+    public int dimensionId;
+    public int entityId;
+    public double x;
+    public double y;
+    public double z;
+    public float yaw;
+    public float pitch;
+
+    public BoatMoveMessage() {
+
+    }
+
+    public BoatMoveMessage(Entity entityIn) {
+        this.dimensionId = entityIn.worldObj.provider.dimensionId;
+        this.entityId = entityIn.getEntityId();
+        this.x = entityIn.posX;
+        this.y = entityIn.posY;
+        this.z = entityIn.posZ;
+        this.yaw = entityIn.rotationYaw;
+        this.pitch = entityIn.rotationPitch;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.dimensionId = buf.readInt();
+        this.entityId = buf.readInt();
+        this.x = buf.readDouble();
+        this.y = buf.readDouble();
+        this.z = buf.readDouble();
+        this.yaw = buf.readFloat();
+        this.pitch = buf.readFloat();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(this.dimensionId);
+        buf.writeInt(this.entityId);
+        buf.writeDouble(this.x);
+        buf.writeDouble(this.y);
+        buf.writeDouble(this.z);
+        buf.writeFloat(this.yaw);
+        buf.writeFloat(this.pitch);
+    }
+}


### PR DESCRIPTION
This PR fixes a couple issues with boats, including #129.

Changes:

* The controlling player now sends a packet to the server every tick with the boat's current position, yaw, and pitch from their perspective. As long as these are plausible, the server allows this and automatically updates its own perspective of the boat. This is essentially a backport of the "vehicle move" packet added in newer versions. With this change, the custom desync logic previously used is no longer required, as the server and client keep each other in sync.
* Boats can now break lilypads.