### PR TITLE
Config for 1.8 Door Buff Recipes

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigBlocksItems.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigBlocksItems.java
@@ -42,6 +42,7 @@ public class ConfigBlocksItems extends ConfigBase {
 	public static boolean enableSponge;
 	public static boolean enablePrismarine;
 	public static boolean enableDoors;
+	public static boolean enableDoorRecipeBuffs;
 	public static boolean enableTrapdoors;
 	public static boolean enableInvertedDaylightSensor;
 	public static boolean enableOldBaseDaylightSensor;
@@ -192,6 +193,7 @@ public class ConfigBlocksItems extends ConfigBase {
 		enableIronTrapdoor = cfg.getBoolean("enableIronTrapdoor", catBlockFunc, true, "");
 		enableSponge = cfg.getBoolean("enableSponge", catBlockFunc, true, "");
 		enableDoors = cfg.getBoolean("enableDoors", catBlockFunc, true, "Enables wood variant doors");
+		enableDoorRecipeBuffs = cfg.getBoolean("enableDoorRecipeBuffs", catBlockFunc, true, "Backports recipe buffs to doors (from 1 to 3)");
 		enableTrapdoors = cfg.getBoolean("enableTrapdoors", catBlockFunc, true, "Enables wood variant trapdoors");
 		enableSlimeBlock = cfg.getBoolean("enableSlimeBlock", catBlockFunc, true, "Just bouncy, does not pull blocks.");
 		enableWoodRedstone = cfg.getBoolean("enableWoodRedstone", catBlockFunc, true, "Enables wood variant buttons and pressure plates");

--- a/src/main/java/ganymedes01/etfuturum/recipes/ModRecipes.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/ModRecipes.java
@@ -384,13 +384,16 @@ public class ModRecipes {
 		}
 
 		if (ConfigBlocksItems.enableDoors) {
+			int output = ConfigBlocksItems.enableDoorRecipeBuffs ? 3 : 1;
 			for (int i = 0; i < ModBlocks.doors.length; i++) {
-				addShapedRecipe(new ItemStack(ModBlocks.doors[i], 3), "xx", "xx", "xx", 'x', new ItemStack(Blocks.planks, 1, i + 1));
+				addShapedRecipe(new ItemStack(ModBlocks.doors[i], output), "xx", "xx", "xx", 'x', new ItemStack(Blocks.planks, 1, i + 1));
 			}
+			if (ConfigBlocksItems.enableDoorRecipeBuffs) {
 			removeFirstRecipeFor(Items.wooden_door);
 			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Items.wooden_door, 3), "xx", "xx", "xx", 'x', "plankWood"));
 			removeFirstRecipeFor(Items.iron_door);
 			GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Items.iron_door, 3), "xx", "xx", "xx", 'x', "ingotIron"));
+			}
 		}
 		
 		if(ConfigBlocksItems.enableTrapdoors) {


### PR DESCRIPTION
Added config to enable/disable Et Futurum's backported buffs to doors introduced by Minecraft 1.8 (from 1 to 3 per crafting operation).

The new buffs can be abused by mods that still expect doors to cost 6 materials each.
Players can abuse this to create dupes such as the Induction Smelter from Thermal Expansion:
![image](https://user-images.githubusercontent.com/47131096/217927399-ea46e7ab-7d25-4dd7-b788-97fdbe59d636.png)
