### PR TITLE
Prevent Null Point Exceptions

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBlastFurnace.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBlastFurnace.java
@@ -378,6 +378,9 @@ public class TileEntityBlastFurnace extends TileEntity implements ISidedInventor
 	@Override
 	public boolean canExtractItem(int p_102008_1_, ItemStack p_102008_2_, int p_102008_3_)
 	{
-		return p_102008_3_ != 0 || p_102008_1_ != 1 || p_102008_2_.getItem() == Items.bucket;
+		if (p_102008_2_ != null)
+			return p_102008_3_ != 0 || p_102008_1_ != 1 || p_102008_2_.getItem() == Items.bucket;
+
+		return false;
 	}
 }

--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntitySmoker.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntitySmoker.java
@@ -382,6 +382,9 @@ public class TileEntitySmoker extends TileEntity implements ISidedInventory
 	@Override
 	public boolean canExtractItem(int p_102008_1_, ItemStack p_102008_2_, int p_102008_3_)
 	{
-		return p_102008_3_ != 0 || p_102008_1_ != 1 || p_102008_2_.getItem() == Items.bucket;
+		if (p_102008_2_ != null)
+			return p_102008_3_ != 0 || p_102008_1_ != 1 || p_102008_2_.getItem() == Items.bucket;
+
+		return false;
 	}
 }


### PR DESCRIPTION
Prevent NPE on the Smoker and Blast furnace when null or invalid itemstacks are used.