### PR TITLE
Fix incorrect name for vanilla Chiseled Sandstone + fix etfuturuN for bee nest (ru_RU.lang)

### DIFF
--- a/src/main/resources/assets/etfuturum/lang/en_US.lang
+++ b/src/main/resources/assets/etfuturum/lang/en_US.lang
@@ -560,7 +560,7 @@ tile.etfuturum.nether_wart.name=Nether Wart Block
 tile.etfuturum.bone.name=Bone Block
 
 tile.etfuturum.tinted_glass.name=Tinted Glass
-tile.etfuturun.bee_nest.name=Bee Nest
+tile.etfuturum.bee_nest.name=Bee Nest
 tile.etfuturum.beehive.name=Beehive
 tile.etfuturum.honey_block.name=Honey Block
 tile.etfuturum.honeycomb_block.name=Honeycomb Block

--- a/src/main/resources/assets/etfuturum/lang/ru_RU.lang
+++ b/src/main/resources/assets/etfuturum/lang/ru_RU.lang
@@ -559,7 +559,7 @@ tile.etfuturum.magma.name=Магмовый блок
 tile.etfuturum.nether_wart.name=Блок адского нароста
 tile.etfuturum.bone.name=Костяной блок
 
-tile.etfuturun.bee_nest.name=Пчелиное гнездо
+tile.etfuturum.bee_nest.name=Пчелиное гнездо
 tile.etfuturum.beehive.name=Улей 
 tile.etfuturum.honey_block.name=Блок мёда
 tile.etfuturum.honeycomb_block.name=Блок пчелиных сот

--- a/src/main/resources/resourcepacks/vanilla_overrides/assets/minecraft/lang/ru_RU.lang
+++ b/src/main/resources/resourcepacks/vanilla_overrides/assets/minecraft/lang/ru_RU.lang
@@ -58,6 +58,7 @@ tile.quartzBlock.lines.name=Кварцевый пилон
 tile.mobSpawner.name=Спаунер
 tile.stoneMoss.name=Замшелый булыжник
 tile.sandStone.smooth.name=Резной песчаник
+tile.sandStone.chiseled.name=Декоративный песчаник
 tile.netherBrick.name=Адские кирпичи
 tile.daylightDetector.name=Датчик дневного света
 


### PR DESCRIPTION
In vanilla, it's called Cut Sandstone, but it's actually Chiseled Sandstone.
This pr makes its name correct (in fact, we have 2 Cut Sandstone with efr)

#### Vanilla:
![16246Снимок](https://github.com/Roadhog360/Et-Futurum-Requiem/assets/110309314/04cc920f-9492-4461-b2a4-1edef47ff887)

#### This pr:
![78798Снимок](https://github.com/Roadhog360/Et-Futurum-Requiem/assets/110309314/4311e40a-e5e2-4bc4-a18b-3063e44dac7a)
