### PR TITLE
Fix KCauldron crash in `ServerEventHandler`

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
@@ -1690,7 +1690,7 @@ public class ServerEventHandler {
 		if (ConfigMixins.enableElytra && e.phase == TickEvent.Phase.END && e.world instanceof WorldServer) {
 			WorldServer ws = (WorldServer) e.world;
 			for (EntityTrackerEntry ete : (Set<EntityTrackerEntry>) ws.getEntityTracker().trackedEntities) {
-				if (ete.myEntity instanceof IElytraPlayer) {
+				if (ete != null && ete.myEntity instanceof IElytraPlayer) {
 					IElytraPlayer elb = (IElytraPlayer) ete.myEntity;
 					boolean flying = elb.etfu$isElytraFlying();
 					if (!flying && ((IElytraEntityTrackerEntry) ete).etfu$getWasSendingVelUpdates()) {


### PR DESCRIPTION
We have encountered a crash when trying to run Et Futurum Requiem 2.5.1 on a KCauldron-based server, with the stacktrace as presented below:

```
[20:24:11] [Server thread/ERROR] [net.minecraft.server.MinecraftServer/]: Encountered an unexpected exception
java.lang.NullPointerException
	at ganymedes01.etfuturum.core.handlers.ServerEventHandler.onPostWorldTick(ServerEventHandler.java:1693) ~[ServerEventHandler.class:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler_42_ServerEventHandler_onPostWorldTick_WorldTickEvent.invoke(.dynamic) ~[?:?]
	at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54) ~[ASMEventHandler.class:1.7.10-R0.1-SNAPSHOT]
	at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140) ~[EventBus.class:1.7.10-R0.1-SNAPSHOT]
	at cpw.mods.fml.common.FMLCommonHandler.onPostWorldTick(FMLCommonHandler.java:260) ~[FMLCommonHandler.class:1.7.10-R0.1-SNAPSHOT]
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:974) ~[MinecraftServer.class:?]
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:431) ~[lt.class:?]
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:809) ~[MinecraftServer.class:?]
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:669) [MinecraftServer.class:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_191]
```

Upon short investigation, it seems `trackedEntities` set from `net.minecraft.entity.EntityTracker` sometimes contains `null` elements, which is never the case on vanilla. I'm not sure whether this can be fixed by adjusting server configuration, but adding a simple null check on the side of the mod seems to work just fine. The change is quite small, so we believe it would be appropriate to merge it upstream.