### PR TITLE
Azalea Fixes & Moss Fixes

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockAzalea.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockAzalea.java
@@ -10,7 +10,9 @@ import net.minecraft.block.BlockBush;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
@@ -72,6 +74,18 @@ public class BlockAzalea extends BlockBush implements ISubBlocksBlock {
 	}
 
 	@Override
+	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z) {
+		return AxisAlignedBB.getBoundingBox(x + 0.0F, y + 0.5F, z + 0.0F, x + 1.0F, y + 1.0F, z + 1.0F);
+	}
+
+	@Override
+	public void getSubBlocks(Item item, CreativeTabs tab, List list) {
+		for (int i = 0; i < getTypes().length; i++) {
+			list.add(new ItemStack(item, 1, i));
+		}
+	}
+
+	@Override
 	public boolean isReplaceable(IBlockAccess world, int x, int y, int z) {
 		return false;
 	}
@@ -96,6 +110,11 @@ public class BlockAzalea extends BlockBush implements ISubBlocksBlock {
 		sideIcons[1] = p_149651_1_.registerIcon("flowering_" + this.getTextureName() + "_side");
 		topIcons[0] = p_149651_1_.registerIcon(this.getTextureName() + "_top");
 		topIcons[1] = p_149651_1_.registerIcon("flowering_" + this.getTextureName() + "_top");
+	}
+
+	@Override
+	public int damageDropped(int meta) {
+		return meta % getTypes().length;
 	}
 
 	@Override

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockMoss.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockMoss.java
@@ -40,12 +40,12 @@ public class BlockMoss extends BaseBlock implements IGrowable {
 	}
 
 	// Adjust the weights as needed
-	private static final int AZALEA_BUSH_WEIGHT = 5;       // Adjust this weight as needed
-	private static final int FLOWERING_AZALEA_WEIGHT = 5;  // Adjust this weight as needed
-	private static final int DOUBLE_TALL_GRASS_WEIGHT = 10; // Adjust this weight as needed
-	private static final int MOSS_CARPET_WEIGHT = 30;      // Adjust this weight as needed
-	private static final int TALL_GRASS_WEIGHT = 15;        // Adjust this weight as needed
-	private static final int AIR_WEIGHT = 25;              // Adjust this weight as needed
+	private static final int AZALEA_BUSH_WEIGHT = 5;
+	private static final int FLOWERING_AZALEA_WEIGHT = 5;
+	private static final int DOUBLE_TALL_GRASS_WEIGHT = 10;
+	private static final int MOSS_CARPET_WEIGHT = 20;
+	private static final int TALL_GRASS_WEIGHT = 10;
+	private static final int AIR_WEIGHT = 50;
 
 	@Override
 	public void func_149853_b(World world, Random rand, int xCoord, int yCoord, int zCoord) {
@@ -91,18 +91,17 @@ public class BlockMoss extends BaseBlock implements IGrowable {
 							);
 
 							if (randomOption < AZALEA_BUSH_WEIGHT) {
-								if (Blocks.red_flower.canBlockStay(world, i1, j1 + 1, k1)) {
-									world.setBlock(i1, j1 + 1, k1, Blocks.red_flower, 0, 2);
+								if (ModBlocks.AZALEA.get().canBlockStay(world, i1, j1 + 1, k1)) {
+									world.setBlock(i1, j1 + 1, k1, ModBlocks.AZALEA.get(), 0, 2);
 								}
 							} else if (randomOption < AZALEA_BUSH_WEIGHT + FLOWERING_AZALEA_WEIGHT) {
-								if (Blocks.yellow_flower.canBlockStay(world, i1, j1 + 1, k1)) {
-									world.setBlock(i1, j1 + 1, k1, Blocks.yellow_flower, 0, 2);
+								if (ModBlocks.AZALEA.get().canBlockStay(world, i1, j1 + 1, k1)) {
+									world.setBlock(i1, j1 + 1, k1, ModBlocks.AZALEA.get(), 1, 2);
 								}
 							} else if (randomOption < AZALEA_BUSH_WEIGHT + FLOWERING_AZALEA_WEIGHT + DOUBLE_TALL_GRASS_WEIGHT) {
 								// Double Tall Grass
 								if (Blocks.double_plant.canBlockStay(world, i1, j1 + 1, k1)) {
-									// TODO: Fix only bottom half of Double Tall Grass placing
-									world.setBlock(i1, j1 + 1, k1, Blocks.double_plant, 2, 2); // Use metadata 2 for double tall grass
+									Blocks.double_plant.func_149889_c(world, i1, j1 + 1, k1, 2, 2);
 								}
 							} else if (randomOption < AZALEA_BUSH_WEIGHT + FLOWERING_AZALEA_WEIGHT + DOUBLE_TALL_GRASS_WEIGHT + MOSS_CARPET_WEIGHT) {
 								// Place Moss Carpet

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockMoss.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockMoss.java
@@ -40,12 +40,12 @@ public class BlockMoss extends BaseBlock implements IGrowable {
 	}
 
 	// Adjust the weights as needed
-	private static final int AZALEA_BUSH_WEIGHT = 5;
-	private static final int FLOWERING_AZALEA_WEIGHT = 5;
-	private static final int DOUBLE_TALL_GRASS_WEIGHT = 10;
-	private static final int MOSS_CARPET_WEIGHT = 20;
-	private static final int TALL_GRASS_WEIGHT = 10;
-	private static final int AIR_WEIGHT = 50;
+	private static final int AZALEA_BUSH_WEIGHT = 2;
+	private static final int FLOWERING_AZALEA_WEIGHT = 1;
+	private static final int DOUBLE_TALL_GRASS_WEIGHT = 1;
+	private static final int MOSS_CARPET_WEIGHT = 10;
+	private static final int TALL_GRASS_WEIGHT = 7;
+	private static final int AIR_WEIGHT = 79;
 
 	@Override
 	public void func_149853_b(World world, Random rand, int xCoord, int yCoord, int zCoord) {


### PR DESCRIPTION
Azalea Fixes
- Fixes SubBlocks
- Fixes Collisions Box

Moss
- Fixes Double Tall Grass
- % Adjusted Weights for Spawning Azaleas
- Added Azaleas to Bone Meal Moss