### PR TITLE
Fix crash on startup on large modpack

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre.java
@@ -25,12 +25,12 @@ import net.minecraft.world.World;
 import java.util.List;
 import java.util.Random;
 
-public class BlockDeepslateOre extends BlockOre {
+public class BlockDeepslateOre extends Block {
 
 	public Block base;
 
 	public BlockDeepslateOre(Block block, boolean defaultMapping) {
-		super();
+		super(block.getMaterial());
 		setAttribs(this, block);
 		base = block;
 		if (getClass().getName().startsWith("ganymedes01.etfuturum")) { //We only want to do this on my own stuff, not mods that extend it.
@@ -77,7 +77,9 @@ public class BlockDeepslateOre extends BlockOre {
 	public int quantityDroppedWithBonus(int i, Random p_149745_1_) {
 		return base.quantityDroppedWithBonus(i, p_149745_1_);
 	}
-
+	public void dropBlockAsItemWithChance(World p_149690_1_, int p_149690_2_, int p_149690_3_, int p_149690_4_, int p_149690_5_, float p_149690_6_, int p_149690_7_) {
+		super.dropBlockAsItemWithChance(p_149690_1_, p_149690_2_, p_149690_3_, p_149690_4_, p_149690_5_, p_149690_6_, p_149690_7_);
+	}
 	@Override
 	public int getExpDrop(IBlockAccess p_149690_1_, int p_149690_5_, int p_149690_7_) {
 		return base.getExpDrop(p_149690_1_, p_149690_5_, p_149690_7_);


### PR DESCRIPTION
````
---- Minecraft Crash Report ----
// Don't do that.

Time: 11/8/23 12:25 PM
Description: There was a severe problem during mod loading that has caused the game to fail

cpw.mods.fml.common.LoaderException: java.lang.VerifyError: Bad access to protected data in getfield
Exception Details:
  Location:
    ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre.<init>(Lnet/minecraft/block/Block;Z)V @43: getfield
  Reason:
    Type 'net/minecraft/block/Block' (current frame, stack[2]) is not assignable to 'ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre'
  Current Frame:
    bci: @43
    flags: { }
    locals: { 'ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre', 'net/minecraft/block/Block', integer }
    stack: { 'ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre', 'java/lang/StringBuilder', 'net/minecraft/block/Block' }
  Bytecode:
    0x0000000: 2ab7 0011 2a2b b800 152a 2bb5 0017 2ab6
    0x0000010: 001d b600 2312 25b6 002b 9900 472a bb00
    0x0000020: 2d59 b700 2e12 30b6 0034 2bb4 0038 b600
    0x0000030: 3bb6 0034 b600 3eb8 0044 b600 4857 2abb
    0x0000040: 002d 59b7 002e 1230 b600 342b b400 38b6
    0x0000050: 0034 b600 3eb6 004b 572a b200 51b6 0055
    0x0000060: 571c 9900 072a b600 58b1
  Stackmap Table:
    full_frame(@97,{Object[#2],Object[#9],Integer},{})
    same_frame(@105)

	at cpw.mods.fml.common.LoadController.transition(LoadController.java:163)
	at cpw.mods.fml.common.Loader.preinitializeMods(Loader.java:559)
	at cpw.mods.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:243)
	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:480)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:8902)
	at net.minecraft.client.main.Main.main(SourceFile:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:88)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:126)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:71)
Caused by: java.lang.VerifyError: Bad access to protected data in getfield
Exception Details:
  Location:
    ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre.<init>(Lnet/minecraft/block/Block;Z)V @43: getfield
  Reason:
    Type 'net/minecraft/block/Block' (current frame, stack[2]) is not assignable to 'ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre'
  Current Frame:
    bci: @43
    flags: { }
    locals: { 'ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre', 'net/minecraft/block/Block', integer }
    stack: { 'ganymedes01/etfuturum/blocks/ores/BlockDeepslateOre', 'java/lang/StringBuilder', 'net/minecraft/block/Block' }
  Bytecode:
    0x0000000: 2ab7 0011 2a2b b800 152a 2bb5 0017 2ab6
    0x0000010: 001d b600 2312 25b6 002b 9900 472a bb00
    0x0000020: 2d59 b700 2e12 30b6 0034 2bb4 0038 b600
    0x0000030: 3bb6 0034 b600 3eb8 0044 b600 4857 2abb
    0x0000040: 002d 59b7 002e 1230 b600 342b b400 38b6
    0x0000050: 0034 b600 3eb6 004b 572a b200 51b6 0055
    0x0000060: 571c 9900 072a b600 58b1
  Stackmap Table:
    full_frame(@97,{Object[#2],Object[#9],Integer},{})
    same_frame(@105)

	at ganymedes01.etfuturum.ModBlocks.<clinit>(ModBlocks.java:70)
	at ganymedes01.etfuturum.EtFuturum.preInit(EtFuturum.java:202)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532)
	at sun.reflect.GeneratedMethodAccessor13.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212)
	at cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119)
	at cpw.mods.fml.common.Loader.preinitializeMods(Loader.java:556)
	... 13 more