### PR TITLE
Angelica Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ dependencies {
 	compileOnly "codechicken:NotEnoughItems:1.7.10-1.0.5.120:dev"
 	compileOnly "codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev"
 	compileOnly "codechicken:CodeChickenCore:1.7.10-1.0.7.47:dev"
-	compileOnly("com.github.GTNewHorizons:Angelica:1.0.0-alpha19:dev") {
+	compileOnly("com.github.GTNewHorizons:Angelica:1.0.0-alpha19:api") {
 		transitive = false
 	}
 	

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,15 @@ buildscript {
 
 repositories {
 	maven {
-		url 'https://jitpack.io'
-	}
-	maven {
 		name = "gt"
 		url = "https://gregtech.mechaenetia.com/"
+	}
+	maven {
+		name = "GTNH Maven"
+		url = "https://nexus.gtnewhorizons.com/repository/public/"
+	}
+	maven {
+		url 'https://jitpack.io'
 	}
 }
 
@@ -109,9 +113,11 @@ dependencies {
 	compileOnly "codechicken:NotEnoughItems:1.7.10-1.0.5.120:dev"
 	compileOnly "codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev"
 	compileOnly "codechicken:CodeChickenCore:1.7.10-1.0.7.47:dev"
+	compileOnly("com.github.GTNewHorizons:Angelica:1.0.0-alpha19:dev") {
+		transitive = false
+	}
 	
-	// 1.1.12 (for some reason the build failed when I used the version tag)
-	compileOnly("com.github.GTNewHorizons:lwjgl3ify:92b1e089c5:api") {
+	compileOnly("com.github.GTNewHorizons:lwjgl3ify:1.5.14:api") {
 		transitive = false
 	}
 	

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockAmethystClusterRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockAmethystClusterRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -8,6 +9,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockAmethystClusterRenderer extends BlockModelBase {
 
 	public BlockAmethystClusterRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockAmethystClusterRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockAmethystClusterRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -9,7 +9,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockAmethystClusterRenderer extends BlockModelBase {
 
 	public BlockAmethystClusterRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockAzaleaRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockAzaleaRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
@@ -9,7 +9,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockAzaleaRenderer extends BlockModelBase {
 
 	public BlockAzaleaRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockAzaleaRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockAzaleaRenderer.java
@@ -1,12 +1,15 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
+@ThreadSafeISBRH
 public class BlockAzaleaRenderer extends BlockModelBase {
 
 	public BlockAzaleaRenderer(int modelID) {
@@ -14,6 +17,7 @@ public class BlockAzaleaRenderer extends BlockModelBase {
 	}
 
 	protected void renderInventoryModel(Block block, int meta, int modelId, RenderBlocks renderer, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+		final Tessellator tessellator = Tessellator.instance;
 		//We have to render each side manually because the bottom side gets rendered even though we set shouldSideBeRendered to false on side 0 (bottom)
 		renderer.setRenderBounds(0, 0, 0, 1, 1, 1);
 		tessellator.setNormal(0.0F, 1.0F, 0.0F);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockBambooRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockBambooRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import ganymedes01.etfuturum.blocks.BlockBamboo;
 import ganymedes01.etfuturum.core.utils.Utils;
 import net.minecraft.block.Block;
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockBambooRenderer extends BlockModelBase {
 	public BlockBambooRenderer(int modelID) {
 		super(modelID);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockBambooRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockBambooRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import ganymedes01.etfuturum.blocks.BlockBamboo;
 import ganymedes01.etfuturum.core.utils.Utils;
 import net.minecraft.block.Block;
@@ -7,6 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockBambooRenderer extends BlockModelBase {
 	public BlockBambooRenderer(int modelID) {
 		super(modelID);
@@ -60,4 +62,5 @@ public class BlockBambooRenderer extends BlockModelBase {
 //		}
 		return true;
 	}
+
 }

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockBarrelRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockBarrelRenderer.java
@@ -1,10 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockPistonBase;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockBarrelRenderer extends BlockModelBase {
 
 	public BlockBarrelRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockBarrelRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockBarrelRenderer.java
@@ -1,12 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockPistonBase;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockBarrelRenderer extends BlockModelBase {
 
 	public BlockBarrelRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockCauldronBaseRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockCauldronBaseRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCauldron;
 import net.minecraft.client.renderer.EntityRenderer;
@@ -8,6 +9,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockCauldronBaseRenderer extends BlockModelBase {
 	public BlockCauldronBaseRenderer(int modelID) {
 		super(modelID);
@@ -45,4 +47,6 @@ public class BlockCauldronBaseRenderer extends BlockModelBase {
 		renderer.renderFaceYNeg(block, x, (double) y + 1.0F - 0.75F, z, iicon2);
 		return true;
 	}
+
+
 }

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockCauldronBaseRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockCauldronBaseRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCauldron;
 import net.minecraft.client.renderer.EntityRenderer;
@@ -9,7 +9,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockCauldronBaseRenderer extends BlockModelBase {
 	public BlockCauldronBaseRenderer(int modelID) {
 		super(modelID);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChainRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChainRenderer.java
@@ -1,10 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockChainRenderer extends BlockModelBase {
 	public BlockChainRenderer(int modelID) {
 		super(modelID);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChainRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChainRenderer.java
@@ -1,12 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockChainRenderer extends BlockModelBase {
 	public BlockChainRenderer(int modelID) {
 		super(modelID);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChestRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChestRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -9,6 +10,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
+@ThreadSafeISBRH
 public class BlockChestRenderer implements ISimpleBlockRenderingHandler {
 
 	@Override

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChestRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChestRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -10,7 +10,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockChestRenderer implements ISimpleBlockRenderingHandler {
 
 	@Override

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChorusFlowerRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChorusFlowerRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
@@ -7,6 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
+@ThreadSafeISBRH
 public class BlockChorusFlowerRenderer extends BlockModelBase {
 
 	public BlockChorusFlowerRenderer(int modelId) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChorusFlowerRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChorusFlowerRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockChorusFlowerRenderer extends BlockModelBase {
 
 	public BlockChorusFlowerRenderer(int modelId) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChorusPlantRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChorusPlantRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.ModBlocks;
@@ -13,6 +14,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import java.util.Random;
 
 @SideOnly(Side.CLIENT)
+@ThreadSafeISBRH
 public class BlockChorusPlantRenderer extends BlockChorusFlowerRenderer {
 
 	private final Random rand = new RandomXoshiro256StarStar();

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChorusPlantRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockChorusPlantRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.ModBlocks;
@@ -14,7 +14,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import java.util.Random;
 
 @SideOnly(Side.CLIENT)
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockChorusPlantRenderer extends BlockChorusFlowerRenderer {
 
 	private final Random rand = new RandomXoshiro256StarStar();

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockColoredWaterCauldronRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockColoredWaterCauldronRenderer.java
@@ -1,14 +1,17 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.blocks.BlockPotionCauldron;
 import ganymedes01.etfuturum.tileentities.TileEntityCauldronColoredWater;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCauldron;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockColoredWaterCauldronRenderer extends BlockCauldronBaseRenderer {
 
 	public BlockColoredWaterCauldronRenderer(int modelID) {
@@ -18,6 +21,7 @@ public class BlockColoredWaterCauldronRenderer extends BlockCauldronBaseRenderer
 	@Override
 	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks renderer) {
 		super.renderWorldBlock(world, x, y, z, block, modelId, renderer);
+		final Tessellator tessellator = Tessellator.instance;
 
 		TileEntityCauldronColoredWater tile = (TileEntityCauldronColoredWater) world.getTileEntity(x, y, z);
 		int color = tile.getWaterColor();

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockColoredWaterCauldronRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockColoredWaterCauldronRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.blocks.BlockPotionCauldron;
 import ganymedes01.etfuturum.tileentities.TileEntityCauldronColoredWater;
@@ -11,7 +11,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockColoredWaterCauldronRenderer extends BlockCauldronBaseRenderer {
 
 	public BlockColoredWaterCauldronRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockComposterRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockComposterRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.blocks.BlockComposter;
 import net.minecraft.block.Block;
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockComposterRenderer extends BlockModelBase {
 
 	public BlockComposterRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockComposterRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockComposterRenderer.java
@@ -1,11 +1,14 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.blocks.BlockComposter;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockComposterRenderer extends BlockModelBase {
 
 	public BlockComposterRenderer(int modelID) {
@@ -13,6 +16,7 @@ public class BlockComposterRenderer extends BlockModelBase {
 	}
 
 	protected void renderStandardInventoryCube(Block block, int meta, int modelID, RenderBlocks renderer, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.setRenderBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
 
 		tessellator.setNormal(0.0F, -1.0F, 0.0F);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockDoorRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockDoorRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
@@ -7,6 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
+@ThreadSafeISBRH
 public class BlockDoorRenderer extends BlockModelBase {
 
 	public BlockDoorRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockDoorRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockDoorRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockDoorRenderer extends BlockModelBase {
 
 	public BlockDoorRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockDoubleLayerRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockDoubleLayerRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
@@ -7,6 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
+@ThreadSafeISBRH
 public class BlockDoubleLayerRenderer extends BlockModelBase {
 
 	private final float innerSizeMax;

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockDoubleLayerRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockDoubleLayerRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockDoubleLayerRenderer extends BlockModelBase {
 
 	private final float innerSizeMax;

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockEmissiveLayerRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockEmissiveLayerRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import ganymedes01.etfuturum.blocks.IEmissiveLayerBlock;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.EntityRenderer;
@@ -10,7 +10,7 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockEmissiveLayerRenderer extends BlockModelBase {
 
 	/**

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockEmissiveLayerRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockEmissiveLayerRenderer.java
@@ -1,13 +1,16 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import ganymedes01.etfuturum.blocks.IEmissiveLayerBlock;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockEmissiveLayerRenderer extends BlockModelBase {
 
 	/**
@@ -38,6 +41,7 @@ public class BlockEmissiveLayerRenderer extends BlockModelBase {
 
 	protected void renderStandardInventoryCubeEmissive(Block block, int meta, int modelId, RenderBlocks renderer, boolean emissive,
 													   double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+		final Tessellator tessellator = Tessellator.instance;
 		if (emissive) {
 			int m = ((IEmissiveLayerBlock) block).getEmissiveLayerColor(meta);
 			float f = (float) (m >> 16 & 255) / 255.0F;
@@ -102,6 +106,7 @@ public class BlockEmissiveLayerRenderer extends BlockModelBase {
 	 * Renders the YNeg face with proper shading like renderStandardBlock.
 	 */
 	private void renderFaceYNeg(RenderBlocks renderer, Block block, double dx, double dy, double dz, int minBrightness, IIcon icon, int meta) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -139,6 +144,7 @@ public class BlockEmissiveLayerRenderer extends BlockModelBase {
 	 * Renders the YPos face with proper shading like renderStandardBlock.
 	 */
 	private void renderFaceYPos(RenderBlocks renderer, Block block, double dx, double dy, double dz, int minBrightness, IIcon icon, int meta) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -176,6 +182,7 @@ public class BlockEmissiveLayerRenderer extends BlockModelBase {
 	 * Renders the ZNeg face with proper shading like renderStandardBlock.
 	 */
 	private void renderFaceZNeg(RenderBlocks renderer, Block block, double dx, double dy, double dz, int minBrightness, IIcon icon, int meta) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -214,6 +221,7 @@ public class BlockEmissiveLayerRenderer extends BlockModelBase {
 	 * Renders the ZPos face with proper shading like renderStandardBlock.
 	 */
 	private void renderFaceZPos(RenderBlocks renderer, Block block, double dx, double dy, double dz, int minBrightness, IIcon icon, int meta) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -252,6 +260,7 @@ public class BlockEmissiveLayerRenderer extends BlockModelBase {
 	 * Renders the XNeg face with proper shading like renderStandardBlock.
 	 */
 	private void renderFaceXNeg(RenderBlocks renderer, Block block, double dx, double dy, double dz, int minBrightness, IIcon icon, int meta) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -290,6 +299,7 @@ public class BlockEmissiveLayerRenderer extends BlockModelBase {
 	 * Renders the XPos face with proper shading like renderStandardBlock.
 	 */
 	private void renderFaceXPos(RenderBlocks renderer, Block block, double dx, double dy, double dz, int minBrightness, IIcon icon, int meta) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockEndRodRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockEndRodRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.client.OpenGLHelper;
@@ -9,6 +10,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
+@ThreadSafeISBRH
 public class BlockEndRodRenderer extends BlockModelBase {
 
 	public BlockEndRodRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockEndRodRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockEndRodRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import ganymedes01.etfuturum.client.OpenGLHelper;
@@ -10,7 +10,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
 @SideOnly(Side.CLIENT)
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockEndRodRenderer extends BlockModelBase {
 
 	public BlockEndRodRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockExtendedCrossedSquaresRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockExtendedCrossedSquaresRenderer.java
@@ -1,11 +1,13 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import ganymedes01.etfuturum.blocks.BlockNetherRoots;
 import ganymedes01.etfuturum.blocks.BlockNetherSprouts;
 import ganymedes01.etfuturum.lib.RenderIDs;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
@@ -13,6 +15,7 @@ import net.minecraft.world.IBlockAccess;
  * Basically the default crossed squares renderer (renderID 1) doesn't call getIcon(IBlockAccess world, int x, int y, int z, int side)
  * This means that we can't have world-sensitive rendering icons with it, so we do this.
  */
+@ThreadSafeISBRH
 public class BlockExtendedCrossedSquaresRenderer extends BlockModelBase {
 	public BlockExtendedCrossedSquaresRenderer() {
 		super(RenderIDs.EXTENDED_CROSSED_SQUARES);
@@ -21,6 +24,7 @@ public class BlockExtendedCrossedSquaresRenderer extends BlockModelBase {
 
 	@Override
 	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks renderer) {
+		final Tessellator tessellator = Tessellator.instance;
 		tessellator.setBrightness(block.getMixedBrightnessForBlock(world, x, y, z));
 		int l = block.colorMultiplier(world, x, y, z);
 		float f = (float) (l >> 16 & 255) / 255.0F;
@@ -52,4 +56,5 @@ public class BlockExtendedCrossedSquaresRenderer extends BlockModelBase {
 		renderer.drawCrossedSquares(iicon, d1, y, d0, 1.0F);
 		return true;
 	}
+
 }

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockExtendedCrossedSquaresRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockExtendedCrossedSquaresRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import ganymedes01.etfuturum.blocks.BlockNetherRoots;
 import ganymedes01.etfuturum.blocks.BlockNetherSprouts;
 import ganymedes01.etfuturum.lib.RenderIDs;
@@ -15,7 +15,7 @@ import net.minecraft.world.IBlockAccess;
  * Basically the default crossed squares renderer (renderID 1) doesn't call getIcon(IBlockAccess world, int x, int y, int z, int side)
  * This means that we can't have world-sensitive rendering icons with it, so we do this.
  */
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockExtendedCrossedSquaresRenderer extends BlockModelBase {
 	public BlockExtendedCrossedSquaresRenderer() {
 		super(RenderIDs.EXTENDED_CROSSED_SQUARES);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockGlazedTerracottaRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockGlazedTerracottaRenderer.java
@@ -1,11 +1,11 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockGlazedTerracottaRenderer extends BlockModelBase {
 
 	public BlockGlazedTerracottaRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockGlazedTerracottaRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockGlazedTerracottaRenderer.java
@@ -1,9 +1,11 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockGlazedTerracottaRenderer extends BlockModelBase {
 
 	public BlockGlazedTerracottaRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLanternRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLanternRenderer.java
@@ -1,10 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockLanternRenderer extends BlockModelBase {
 
 	public BlockLanternRenderer(int modelID) {
@@ -53,4 +55,5 @@ public class BlockLanternRenderer extends BlockModelBase {
 
 		return true;
 	}
+
 }

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLanternRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLanternRenderer.java
@@ -1,12 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockLanternRenderer extends BlockModelBase {
 
 	public BlockLanternRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLavaCauldronRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLavaCauldronRenderer.java
@@ -1,11 +1,13 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockLavaCauldronRenderer extends BlockCauldronBaseRenderer {
 
 	public BlockLavaCauldronRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLavaCauldronRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLavaCauldronRenderer.java
@@ -1,13 +1,13 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockLavaCauldronRenderer extends BlockCauldronBaseRenderer {
 
 	public BlockLavaCauldronRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLoomRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLoomRenderer.java
@@ -1,11 +1,11 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockLoomRenderer extends BlockModelBase {
 
 	public BlockLoomRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLoomRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockLoomRenderer.java
@@ -1,9 +1,11 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockLoomRenderer extends BlockModelBase {
 
 	public BlockLoomRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockMangroveRootsRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockMangroveRootsRenderer.java
@@ -1,12 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockMangroveRootsRenderer extends BlockModelBase {
 	public BlockMangroveRootsRenderer(int renderID) {
 		super(renderID);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockMangroveRootsRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockMangroveRootsRenderer.java
@@ -1,9 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockMangroveRootsRenderer extends BlockModelBase {
 	public BlockMangroveRootsRenderer(int renderID) {
 		super(renderID);
@@ -11,6 +14,7 @@ public class BlockMangroveRootsRenderer extends BlockModelBase {
 
 	@Override
 	protected void renderInventoryModel(Block block, int meta, int modelId, RenderBlocks renderer, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+		final Tessellator tessellator = Tessellator.instance;
 		super.renderInventoryModel(block, meta, modelId, renderer, minX, minY, minZ, maxX, maxY, maxZ);
 		boolean prev = renderer.renderFromInside;
 		renderer.renderFromInside = true;

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockModelBase.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockModelBase.java
@@ -17,12 +17,13 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 	private final int modelID;
 	private boolean inventory3D = true;
 
-	public BlockModelBase(int modelID) {
+	protected BlockModelBase(int modelID) {
 		this.modelID = modelID;
 	}
 
 	@Override
 	public void renderInventoryBlock(Block block, int meta, int modelID, RenderBlocks renderer) {
+		final Tessellator tessellator = Tessellator.instance;
 		if (block.getRenderBlockPass() == 1) {
 			OpenGLHelper.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 			OpenGLHelper.enableBlend();
@@ -42,6 +43,7 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 	}
 
 	protected void renderStandardInventoryCube(Block block, int meta, int modelId, RenderBlocks renderer, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.setRenderBounds(minX, minY, minZ, maxX, maxY, maxZ);
 		tessellator.setNormal(0.0F, -1.0F, 0.0F);
 		renderer.renderFaceYNeg(block, 0.0D, 0.0D, 0.0D, renderer.getBlockIconFromSideAndMetadata(block, 0, meta));
@@ -128,6 +130,7 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 							  double startX, double endX, double startY, double endY, double startZ, double endZ,
 							  double startU, double startV, double endU, double endV, IIcon iicon, int rotate,
 							  float r, float g, float b) {
+		final Tessellator tessellator = Tessellator.instance;
 		double startUInterpolated;
 		double startVInterpolated;
 		double endUInterpolated;
@@ -231,6 +234,7 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 	 * Renders the YNeg face with proper shading like renderStandardBlock.
 	 */
 	public void renderFaceYNeg(RenderBlocks renderer, Block block, double dx, double dy, double dz, double offx, double offy, double offz) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -257,6 +261,7 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 	 * Renders the YPos face with proper shading like renderStandardBlock.
 	 */
 	public void renderFaceYPos(RenderBlocks renderer, Block block, double dx, double dy, double dz, double offx, double offy, double offz) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -301,6 +306,7 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 	 * Renders the ZNeg face with proper shading like renderStandardBlock.
 	 */
 	public void renderFaceZNeg(RenderBlocks renderer, Block block, double dx, double dy, double dz, double offx, double offy, double offz) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -328,6 +334,7 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 	 * Renders the ZPos face with proper shading like renderStandardBlock.
 	 */
 	public void renderFaceZPos(RenderBlocks renderer, Block block, double dx, double dy, double dz, double offx, double offy, double offz) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -355,6 +362,7 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 	 * Renders the XNeg face with proper shading like renderStandardBlock.
 	 */
 	public void renderFaceXNeg(RenderBlocks renderer, Block block, double dx, double dy, double dz, double offx, double offy, double offz) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);
@@ -383,6 +391,7 @@ public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 	 * Renders the XPos face with proper shading like renderStandardBlock.
 	 */
 	public void renderFaceXPos(RenderBlocks renderer, Block block, double dx, double dy, double dz, double offx, double offy, double offz) {
+		final Tessellator tessellator = Tessellator.instance;
 		renderer.enableAO = false;
 
 		int x = MathHelper.floor_double(dx);

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockModelBase.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockModelBase.java
@@ -13,7 +13,6 @@ import org.lwjgl.opengl.GL11;
 
 public abstract class BlockModelBase implements ISimpleBlockRenderingHandler {
 
-	protected static final Tessellator tessellator = Tessellator.instance;
 	private final int modelID;
 	private boolean inventory3D = true;
 

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockNewFenceRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockNewFenceRenderer.java
@@ -1,11 +1,14 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import ganymedes01.etfuturum.lib.RenderIDs;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFence;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockNewFenceRenderer extends BlockModelBase {
 
 	public BlockNewFenceRenderer() {
@@ -14,6 +17,7 @@ public class BlockNewFenceRenderer extends BlockModelBase {
 
 	@Override
 	protected void renderInventoryModel(Block block, int meta, int modelId, RenderBlocks renderer, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+		final Tessellator tessellator = Tessellator.instance;
 		for (int k = 0; k < 4; ++k) {
 			float f2 = 0.125F;
 

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockNewFenceRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockNewFenceRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import ganymedes01.etfuturum.lib.RenderIDs;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFence;
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockNewFenceRenderer extends BlockModelBase {
 
 	public BlockNewFenceRenderer() {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockObserverRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockObserverRenderer.java
@@ -1,12 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockPistonBase;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockObserverRenderer extends BlockModelBase {
 
 	public BlockObserverRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockObserverRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockObserverRenderer.java
@@ -1,10 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockPistonBase;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockObserverRenderer extends BlockModelBase {
 
 	public BlockObserverRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockPinkPetalsRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockPinkPetalsRenderer.java
@@ -1,13 +1,13 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockPinkPetalsRenderer extends BlockModelBase {
 
 	public BlockPinkPetalsRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockPinkPetalsRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockPinkPetalsRenderer.java
@@ -1,10 +1,13 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockPinkPetalsRenderer extends BlockModelBase {
 
 	public BlockPinkPetalsRenderer(int modelID) {
@@ -13,6 +16,7 @@ public class BlockPinkPetalsRenderer extends BlockModelBase {
 
 	@Override
 	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks renderer) {
+		final Tessellator tessellator = Tessellator.instance;
 		int meta = world.getBlockMetadata(x, y, z);
 		int count = meta % 4;
 		int rotation = meta / 4;

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockPointedDripstoneRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockPointedDripstoneRenderer.java
@@ -1,5 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -7,6 +8,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockPointedDripstoneRenderer extends BlockModelBase {
 
 	public BlockPointedDripstoneRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockPointedDripstoneRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockPointedDripstoneRenderer.java
@@ -1,6 +1,6 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockPointedDripstoneRenderer extends BlockModelBase {
 
 	public BlockPointedDripstoneRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockStonecutterRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockStonecutterRenderer.java
@@ -1,10 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import ganymedes01.etfuturum.blocks.BlockStonecutter;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
+@ThreadSafeISBRH
 public class BlockStonecutterRenderer extends BlockModelBase {
 
 	public BlockStonecutterRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockStonecutterRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockStonecutterRenderer.java
@@ -1,12 +1,12 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import ganymedes01.etfuturum.blocks.BlockStonecutter;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockStonecutterRenderer extends BlockModelBase {
 
 	public BlockStonecutterRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockTrapDoorRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockTrapDoorRenderer.java
@@ -1,13 +1,13 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
-import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
+import com.gtnewhorizons.angelica.api.ThreadSafeISBRH;
 import ganymedes01.etfuturum.ModBlocks;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 import org.lwjgl.opengl.GL11;
 
-@ThreadSafeISBRH
+@ThreadSafeISBRH(perThread = false)
 public class BlockTrapDoorRenderer extends BlockModelBase {
 
 	public BlockTrapDoorRenderer(int modelID) {

--- a/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockTrapDoorRenderer.java
+++ b/src/main/java/ganymedes01/etfuturum/client/renderer/block/BlockTrapDoorRenderer.java
@@ -1,11 +1,13 @@
 package ganymedes01.etfuturum.client.renderer.block;
 
+import com.gtnewhorizons.angelica.rendering.ThreadSafeISBRH;
 import ganymedes01.etfuturum.ModBlocks;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 import org.lwjgl.opengl.GL11;
 
+@ThreadSafeISBRH
 public class BlockTrapDoorRenderer extends BlockModelBase {
 
 	public BlockTrapDoorRenderer(int modelID) {


### PR DESCRIPTION
Angelica Support
* Add Angelica as a compile time dependency
* Add the GTNH Maven
* Mark Renderers as thread safe with `@ThreadSafeISBRH`
* Move Tessellator.instance access into the methods so the ASM redirect properly supplies the CapturingTessellator

NOTE: Requires angelica 1.0.0-alpha19+ (not yet published)