### PR TITLE
Backport light level change from 1.18

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigEntities.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigEntities.java
@@ -19,6 +19,7 @@ public class ConfigEntities extends ConfigBase {
 	public static boolean enableNetherEndermen;
 	public static boolean enableShearableSnowGolems;
 	public static boolean enableBees;
+	public static boolean enableLightLevel0;
 
 	static final String catHostile = "hostile";
 	static final String catNeutral = "neutral";
@@ -63,6 +64,7 @@ public class ConfigEntities extends ConfigBase {
 		enableVillagerTurnsIntoWitch = getBoolean("enableVillagerTurnsIntoWitch", catMisc, true, "Villagers turn into Witches when struck by lightning");
 		enableDragonRespawn = getBoolean("enableDragonRespawn", catMisc, true, "Crude implementation of respawning the dragon using four End crystals.");
 		enableNetherEndermen = getBoolean("enableNetherEndermen", catMisc, true, "Allow endermen to rarely spawn in the Nether");
+		enableLightLevel0 = getBoolean("enableLightLevel0", catMisc, false, "This config reducec the required light level for mobs to spawn to light level 0, like in Minecraft 1.18+.");
 	}
 
 }

--- a/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
@@ -1955,6 +1955,19 @@ public class ServerEventHandler {
 			e.world.getGameRules().addGameRule("disableElytraMovementCheck", "false");
 	}
 
+	@SubscribeEvent
+	public void onEntitySpawn(LivingSpawnEvent.CheckSpawn event) {
+		if (ConfigEntities.enableLightLevel0 && event.entityLiving instanceof IMob) {
+			int x = MathHelper.floor_double(event.entityLiving.posX);
+            int y = MathHelper.floor_double(event.entityLiving.boundingBox.minY);
+            int z = MathHelper.floor_double(event.entityLiving.posZ);
+
+            if (event.entityLiving.worldObj.getBlockLightValue(x, y, z) > 0) {
+                event.setResult(Result.DENY);
+            }
+		}
+	}
+
 	static MovingObjectPosition getMovingObjectPositionFromPlayer(World worldIn, EntityPlayer playerIn, boolean useLiquids) {
 		float f = 1.0F;
 		float f1 = playerIn.prevRotationPitch + (playerIn.rotationPitch - playerIn.prevRotationPitch) * f;

--- a/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/core/handlers/ServerEventHandler.java
@@ -1959,12 +1959,12 @@ public class ServerEventHandler {
 	public void onEntitySpawn(LivingSpawnEvent.CheckSpawn event) {
 		if (ConfigEntities.enableLightLevel0 && event.entityLiving instanceof IMob) {
 			int x = MathHelper.floor_double(event.entityLiving.posX);
-            int y = MathHelper.floor_double(event.entityLiving.boundingBox.minY);
-            int z = MathHelper.floor_double(event.entityLiving.posZ);
-
-            if (event.entityLiving.worldObj.getBlockLightValue(x, y, z) > 0) {
-                event.setResult(Result.DENY);
-            }
+			int y = MathHelper.floor_double(event.entityLiving.boundingBox.minY);
+			int z = MathHelper.floor_double(event.entityLiving.posZ);
+			
+			if (event.entityLiving.worldObj.getBlockLightValue(x, y, z) > 0) {
+				event.setResult(Result.DENY);
+			}
 		}
 	}
 


### PR DESCRIPTION
Sets the light level to 0 for mobs. Like in Minecraft 1.18+.
The config is false by default. Not sure if I should set it to true. Your decision.