### PR TITLE
add raw ores to ticon smeltery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,11 @@ dependencies {
 	compileOnly "codechicken:NotEnoughItems:1.7.10-1.0.5.120:dev"
 	compileOnly "codechicken:CodeChickenLib:1.7.10-1.1.3.140:dev"
 	compileOnly "codechicken:CodeChickenCore:1.7.10-1.0.7.47:dev"
+
+	compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.11.12-GTNH:dev") {
+		transitive = false
+	}
+
 	compileOnly("com.github.GTNewHorizons:Angelica:1.0.0-alpha19:api") {
 		transitive = false
 	}

--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -373,6 +373,10 @@ public class EtFuturum {
 		CompostingRegistry.init();
 		BeePlantRegistry.init();
 		PistonBehaviorRegistry.init();
+
+		if (ModsList.TINKERS_CONSTRUCT.isLoaded()) {
+			CompatTinkersConstruct.postInit();
+		}
 	}
 
 	@EventHandler

--- a/src/main/java/ganymedes01/etfuturum/compat/CompatTinkersConstruct.java
+++ b/src/main/java/ganymedes01/etfuturum/compat/CompatTinkersConstruct.java
@@ -1,0 +1,60 @@
+package ganymedes01.etfuturum.compat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import ganymedes01.etfuturum.api.RawOreRegistry;
+import ganymedes01.etfuturum.api.mappings.RawOreDropMapping;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
+import tconstruct.library.crafting.Smeltery;
+
+public class CompatTinkersConstruct {
+
+    public static void postInit() {
+        regsiterRawOresToSmeltery();
+    }
+
+    private static void regsiterRawOresToSmeltery() {
+        Map<String, RawOreDropMapping> oreMap = RawOreRegistry.getOreMap();
+
+        for (Entry<String, RawOreDropMapping> kvp : oreMap.entrySet()) {
+            String oreDictName = kvp.getKey();
+            RawOreDropMapping mapping = kvp.getValue();
+            ItemStack melting = new ItemStack(mapping.getObject(), mapping.getMeta());
+            List<ItemStack> allOres = OreDictionary.getOres(oreDictName);
+            ItemStack oreBlock = null;
+
+            // Find an item stack that is a block.
+            for (ItemStack ore : allOres) {
+                if (ore.getItem() instanceof ItemBlock) {
+                    ItemBlock itemBlock = (ItemBlock)ore.getItem();
+                    Block block = Block.getBlockFromItem(itemBlock);
+
+                    if (block != null && block != Blocks.air) {
+                        oreBlock = ore;
+                        break;
+                    }
+                }
+            }
+
+            if (oreBlock != null) {
+                // Collect some infos for the existing block
+                FluidStack liquid = Smeltery.getSmelteryResult(oreBlock);
+                int temperature = Smeltery.getLiquifyTemperature(oreBlock);
+                Block renderBlock = Blocks.air;
+                int renderBlockMeta = 0;
+
+                // Add the melting recipe
+                if (liquid != null) {
+                    Smeltery.addMelting(melting, renderBlock, renderBlockMeta, temperature, liquid);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds all registred raw ores to the smeltery as last step on `postInit`. It tries to find a block via the ore dictionary to get the required informations for registration (like temperature and output).

As block to render it uses "air". The Smeltery then seems to search for a massive block from the output material (like an iron block) to display. This is fine I guess.
- An alternative would be to use the block we use to get temperature and fluid from the smeltery but this may confuse people if they smelt a raw ore and see a ore from Immersive Engeneering for example.
- Another alternative (and the better one) would be to use a raw ore block. But for this I don't know a easy way to get that via our mapping here. Feel free to tweak that or give me a hint how to.

As project dependency I used GTNH-TiCon, but that shouldn't matter at all at runtime. I was not able to use the CurseForge builds at all for some reason.

![grafik](https://github.com/Roadhog360/Et-Futurum-Requiem/assets/23138465/9c155594-c664-4951-8d8c-59fb2d2de905)
![grafik](https://github.com/Roadhog360/Et-Futurum-Requiem/assets/23138465/d8162942-a961-4e4e-b0d1-a08a7e4b2280)
