### PR TITLE
Fix mis-specified hashmap that was making slimes and such occasionall…

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/api/mappings/RegistryMapping.java
+++ b/src/main/java/ganymedes01/etfuturum/api/mappings/RegistryMapping.java
@@ -46,7 +46,7 @@ public class RegistryMapping<T> {
 
 	@Override
 	public int hashCode() {
-		return object.hashCode() + (meta == OreDictionary.WILDCARD_VALUE ? 0 : meta + 1);
+		return object.hashCode(); // Do not hash meta so wildcards and metas all get placed into the same bucket
 	}
 
 	/**


### PR DESCRIPTION
Fix mis-specified hashmap that was making slimes and such occasionally not work right.  It's likely this fixes a variety of heisenbugs.