### PR TITLE
Wrong Tinker's Construct Raw Ore outputs

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/compat/CompatTinkersConstruct.java
+++ b/src/main/java/ganymedes01/etfuturum/compat/CompatTinkersConstruct.java
@@ -26,7 +26,7 @@ public class CompatTinkersConstruct {
 		for (Entry<String, RawOreDropMapping> kvp : oreMap.entrySet()) {
 			String oreDictName = kvp.getKey();
 			RawOreDropMapping mapping = kvp.getValue();
-			ItemStack melting = new ItemStack(mapping.getObject(), mapping.getMeta());
+			ItemStack melting = new ItemStack(mapping.getObject(), 1, mapping.getMeta());
 			List<ItemStack> allOres = OreDictionary.getOres(oreDictName);
 			ItemStack oreBlock = null;
 

--- a/src/main/java/ganymedes01/etfuturum/lib/Reference.java
+++ b/src/main/java/ganymedes01/etfuturum/lib/Reference.java
@@ -7,7 +7,7 @@ public class Reference {
 
 	public static final String MOD_ID = "etfuturum";
 	public static final String MOD_NAME = "Et Futurum Requiem";
-	public static final String DEPENDENCIES = "required-after:Forge@[10.13.4.1558,);after:Thaumcraft@[4.2.3.5,);after:TwilightForest;after:HardcoreEnderExpansion;after:bluepower;after:MineTweaker3;";
+	public static final String DEPENDENCIES = "required-after:Forge@[10.13.4.1558,);after:Thaumcraft@[4.2.3.5,);after:TwilightForest;after:HardcoreEnderExpansion;after:bluepower;after:MineTweaker3;after:TConstruct;";
 	public static final String VERSION_NUMBER = Tags.VERSION;
 	public static final boolean TESTING = Boolean.getBoolean("etfuturum.testing");
 	public static final boolean DEV_ENVIRONMENT = (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");


### PR DESCRIPTION
Probably solution for https://github.com/Roadhog360/Et-Futurum-Requiem/issues/465.
I finally brought myself to look into the problem, and that's what I found.
And as far as I can tell - problem exists, can be reproduced and is indeed an Et Futurum error.
# Whats wrong?
Basically Tinker's smelting recipes of Et Futurum raw ore chunks looks like that:

![image](https://github.com/user-attachments/assets/105983eb-fb2c-4b81-aeef-abfe6f9c14cd)

But **sometimes** they looks like that:

![broken](https://github.com/user-attachments/assets/73bc609b-08d4-4848-a678-1869afad73e1)
# Whats happening?
Knowing the fact that Raw Ores are registered as one item but with different metas, the explanation will not be difficult.
Basically, this line is just stupid:
https://github.com/Roadhog360/Et-Futurum-Requiem/blob/005d13d195f819c39c6872fffeba6b64b47cbfa6/src/main/java/ganymedes01/etfuturum/compat/CompatTinkersConstruct.java#L29
(quick reminder: `ItemStack(Item item, int stackSize, int meta)`, that's how it works)
As a result, all liquids are registered for the same item, and the last liquid registered remains in the recipes (gold one, basically).
# How to reproduce
The only reason this bug is difficult to reproduce is the chaotic nature of its occurrence.
Difficulties in detection lie in two places, in Forge soursecode and in this method:
https://github.com/Roadhog360/Et-Futurum-Requiem/blob/005d13d195f819c39c6872fffeba6b64b47cbfa6/src/main/java/ganymedes01/etfuturum/recipes/ModRecipes.java#L361-L366
In fact, Tinker's Construct and Et Futurum don't have specified relative loading order, and methods that `register oredict for Et Futurum` and `tinker's smeltery oredict recipe maker`  are in the same preInit phase. This results in unpredictable behavior when loading mods. If Tinkers is loaded first, it will not register oredict smelting recipe for raw ores, but when it's not, it will do that, and that will result CORRECT recipes, overriding broken regsiterRawOresToSmeltery().
I don't bother recompiling Et Futurum to test this theory. Instead I made two sample mods, specifying `dependencies = "before:TConstruct;after:etfuturum"` and `dependencies = "before:etfuturum;after:TConstruct"`, and all works exactly like I mentioned before - it brokes when Tinker's Construct is loaded first, and do not otherwise.
I think it’s obvious why mods like am2pg and others can sometimes break et futurum and sometimes may not - they change the order of mod loading via dependencies, but do not necessarily change the **relative** order of Tinker's and Et Futurum.
To prove that regsiterRawOresToSmeltery() is really broken and registerRawItemAsOre config is the one who saves the day sometimes - simply disable that config, and you will see that it's broken all the time, regardless of mod loading order.

I don't damn get paid for this...
