### PR TITLE
Add a config option allowing deepslate to replace all generated stone…

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigWorld.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigWorld.java
@@ -45,6 +45,7 @@ public class ConfigWorld extends ConfigBase {
 	public static boolean enableOceanMonuments;
 	public static int[] deepslateLayerDimensionBlacklist;
 	public static boolean deepslateLayerDimensionBlacklistAsWhitelist;
+	public static int[] replaceAllStoneWithDeepslateDimensionWhitelist;
 	public static boolean enableExtraMesaGold;
 	public static boolean enableMesaMineshaft;
 	public static boolean enableCoarseDirtReplacement;
@@ -157,6 +158,9 @@ public class ConfigWorld extends ConfigBase {
 		deepslateBlacklistProp.comment = "The dimensions the deepslate layer (deepslate generation mode 0) should not spawn in. Does nothing if other deepslate generation modes are used.";
 		deepslateLayerDimensionBlacklist = deepslateBlacklistProp.getIntList();
 		deepslateLayerDimensionBlacklistAsWhitelist = getBoolean("deepslateLayerDimensionBlacklistAsWhitelist", catGeneration, false, "Treat the deepslate layer dimension blacklist as a whitelist instead, so it will ONLY generate in those dimensions, instead of excluding those dimensions from generation.");
+		Property replaceAllStoneWithDeepslateDimensionWhitelistProp = get(catGeneration,"replaceAllStoneWithDeepslateDimensionWhitelist",new int[]{});
+		replaceAllStoneWithDeepslateDimensionWhitelistProp.comment="The dimensions the deepslate layer (deepslate generation mode 0) should replace ALL stone in, rather than adhering to the deepslateMaxY limit. Does nothing if other deepslate generation modes are used. Useful if you have a mod that adds more \"layers\" to the overworld, for example.";
+		replaceAllStoneWithDeepslateDimensionWhitelist = replaceAllStoneWithDeepslateDimensionWhitelistProp.getIntList();
 		maxTuffPerCluster = getInt("tuffClusterSize", catGeneration, 32, 0, 64, "Max vein size for tuff blocks in a cluster");
 		enableExtraMesaGold = getBoolean("enableExtraMesaGold", catGeneration, true, "Generate 20 more veins of gold ore from Y 32 to Y 80 in any Mesa biome.");
 		enableMesaMineshaft = getBoolean("enableMesaMineshaft", catGeneration, true, "Generates extra mineshafts in mesa biomes up to y80. If fences are enabled, dark oak wood is used.");

--- a/src/main/java/ganymedes01/etfuturum/world/EtFuturumLateWorldGenerator.java
+++ b/src/main/java/ganymedes01/etfuturum/world/EtFuturumLateWorldGenerator.java
@@ -130,9 +130,9 @@ public class EtFuturumLateWorldGenerator extends EtFuturumWorldGenerator {
 		final int chunkMultiplierX = chunk.xPosition << 4;
 		final int chunkMultiplierZ = chunk.zPosition << 4;
 
-		boolean shouldDimBeJustDeepslate = Arrays.stream(ConfigWorld.replaceAllStoneWithDeepslateDimensionWhitelist).anyMatch(id -> id == chunk.worldObj.provider.dimensionId); //Calculated outside the loops for the sake of performance.
-
-        for (int y = 0; y <= Math.min((shouldDimBeJustDeepslate?255:ConfigWorld.deepslateMaxY), chunk.worldObj.getHeight()); y++) {
+		boolean shouldDimBeJustDeepslate = ArrayUtils.contains(ConfigWorld.replaceAllStoneWithDeepslateDimensionWhitelist,chunk.worldObj.provider.dimensionId);
+		int replaceUnderY = (shouldDimBeJustDeepslate ? chunk.worldObj.getActualHeight() : ConfigWorld.deepslateMaxY);
+        for (int y = 0; y <= Math.min(replaceUnderY, chunk.worldObj.getHeight()); y++) {
 			ExtendedBlockStorage array = chunk.getBlockStorageArray()[y >> 4];
 			for (int x = 0; x < 16; x++) {
 				for (int z = 0; z < 16; z++) {

--- a/src/main/java/ganymedes01/etfuturum/world/EtFuturumLateWorldGenerator.java
+++ b/src/main/java/ganymedes01/etfuturum/world/EtFuturumLateWorldGenerator.java
@@ -18,6 +18,7 @@ import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 import net.minecraft.world.gen.feature.WorldGenMinable;
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -129,11 +130,13 @@ public class EtFuturumLateWorldGenerator extends EtFuturumWorldGenerator {
 		final int chunkMultiplierX = chunk.xPosition << 4;
 		final int chunkMultiplierZ = chunk.zPosition << 4;
 
-		for (int y = 0; y <= Math.min(ConfigWorld.deepslateMaxY, chunk.worldObj.getHeight()); y++) {
+		boolean shouldDimBeJustDeepslate = Arrays.stream(ConfigWorld.replaceAllStoneWithDeepslateDimensionWhitelist).anyMatch(id -> id == chunk.worldObj.provider.dimensionId); //Calculated outside the loops for the sake of performance.
+
+        for (int y = 0; y <= Math.min((shouldDimBeJustDeepslate?255:ConfigWorld.deepslateMaxY), chunk.worldObj.getHeight()); y++) {
 			ExtendedBlockStorage array = chunk.getBlockStorageArray()[y >> 4];
 			for (int x = 0; x < 16; x++) {
 				for (int z = 0; z < 16; z++) {
-					if (ConfigWorld.deepslateMaxY >= 255 || y < ConfigWorld.deepslateMaxY - 4 || y <= ConfigWorld.deepslateMaxY - chunk.worldObj.rand.nextInt(4)) {
+					if (ConfigWorld.deepslateMaxY >= 255 || shouldDimBeJustDeepslate || y < ConfigWorld.deepslateMaxY - 4 || y <= ConfigWorld.deepslateMaxY - chunk.worldObj.rand.nextInt(4)) {
 						worldX = x + chunkMultiplierX;
 						worldZ = z + chunkMultiplierZ;
 


### PR DESCRIPTION
… in specific dimensions
Does what it says on the tin.
Tested to work great with [DeeperCaves](https://modrinth.com/mod/deepercaves)
Functionally all it does is treat `WorldConfig.deepslateMaxY` as though it is set to 255 when generating a chunk in a specified dimension. As such, the same caveats apply when using it on the Overworld - namely your top-soil layers of dirt will be deepslate.