### PR TITLE
Color the sides of grass blocks rendering in the inventory

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigMixins.java
@@ -43,6 +43,7 @@ public class ConfigMixins extends ConfigBase {
 	public static boolean hideSingleLevelEnchants;
 	public static boolean fireproofItems;
 	public static boolean thinPanes;
+	public static boolean colorGrassBlockItemSides;
 
 	static final String catBackport = "backported features";
 	static final String catOptimization = "optimizations";
@@ -104,6 +105,8 @@ public class ConfigMixins extends ConfigBase {
 		fireproofItems = getBoolean("fireproofItems", catBackport, true, "Some items such as Netherite will not burn in fire and will float to the surface of lava.");
 		thinPanes = getBoolean("thinPanes", catBackport, true, "Panes [Iron Bars, Glass Panes, etc] are changed to a single post if they are not connected to any other blocks" +
 				"\nModified Classes: net.minecraft.block.BlockPane" +
+				"\nModified Client Classes: net.minecraft.client.renderer.RenderBlocks");
+		colorGrassBlockItemSides = getBoolean("colorGrassBlockItemSides", catBackport, true, "Grass block sides are colored in the player's inventory" +
 				"\nModified Client Classes: net.minecraft.client.renderer.RenderBlocks");
 
 		stepHeightFix = getBoolean("stepHeightFix", catFixes, true, "Makes the player able to step up even if a block would be above their head at the destination.\nModified classes: net.minecraft.entity.Entity");

--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
@@ -253,6 +253,10 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 			if (ConfigMixins.flowerPotFixes) {
 				mixins.add("flowerpotfix.client.MixinRenderBlocks");
 			}
+
+			if (ConfigMixins.colorGrassBlockItemSides) {
+				mixins.add("coloredgrassitem.client.MixinRenderBlocks");
+			}
 		}
 
 		if (ConfigMixins.thinPanes) {

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/coloredgrassitem/client/MixinRenderBlocks.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/coloredgrassitem/client/MixinRenderBlocks.java
@@ -1,0 +1,71 @@
+package ganymedes01.etfuturum.mixins.early.coloredgrassitem.client;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockGrass;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.util.IIcon;
+import net.minecraftforge.common.util.ForgeDirection;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RenderBlocks.class)
+public abstract class MixinRenderBlocks {
+    @Shadow public static boolean fancyGrass;
+
+    @Shadow public abstract boolean hasOverrideBlockTexture();
+
+    @Shadow public boolean useInventoryTint;
+
+    @Shadow public abstract void renderFaceZNeg(Block p_147761_1_, double p_147761_2_, double p_147761_4_, double p_147761_6_, IIcon p_147761_8_);
+    @Shadow public abstract void renderFaceZPos(Block p_147761_1_, double p_147761_2_, double p_147761_4_, double p_147761_6_, IIcon p_147761_8_);
+    @Shadow public abstract void renderFaceXNeg(Block p_147761_1_, double p_147761_2_, double p_147761_4_, double p_147761_6_, IIcon p_147761_8_);
+    @Shadow public abstract void renderFaceXPos(Block p_147761_1_, double p_147761_2_, double p_147761_4_, double p_147761_6_, IIcon p_147761_8_);
+
+    /**
+     * @author embeddedt
+     * @reason render the grass overlay texture with the appropriate colors
+     */
+    @Inject(method = "renderBlockAsItem", at = @At("RETURN"))
+    private void renderColoredGrassSides(Block block, int meta, float p_147800_3_, CallbackInfo ci, @Local(ordinal = 0) boolean isGrass, @Local(ordinal = 0) Tessellator tessellator) {
+        if (fancyGrass && isGrass && block.getRenderType() == 0 && this.useInventoryTint && !this.hasOverrideBlockTexture()) {
+            GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
+
+            // Set render color
+            int k = block.getRenderColor(meta);
+            float f2 = (float)(k >> 16 & 255) / 255.0F;
+            float f3 = (float)(k >> 8 & 255) / 255.0F;
+            float f4 = (float)(k & 255) / 255.0F;
+            GL11.glColor4f(f2 * p_147800_3_, f3 * p_147800_3_, f4 * p_147800_3_, 1.0F);
+
+            // Render the four faces
+
+            tessellator.startDrawingQuads();
+            tessellator.setNormal(0.0F, 0.0F, -1.0F);
+            double epsilon = 0.001D;
+            this.renderFaceZNeg(block, 0.0D, 0.0D, -epsilon, BlockGrass.getIconSideOverlay());
+            tessellator.draw();
+            tessellator.startDrawingQuads();
+            tessellator.setNormal(0.0F, 0.0F, 1.0F);
+            this.renderFaceZPos(block, 0.0D, 0.0D, epsilon, BlockGrass.getIconSideOverlay());
+            tessellator.draw();
+            tessellator.startDrawingQuads();
+            tessellator.setNormal(-1.0F, 0.0F, 0.0F);
+            this.renderFaceXNeg(block, -epsilon, 0.0D, 0.0D, BlockGrass.getIconSideOverlay());
+            tessellator.draw();
+            tessellator.startDrawingQuads();
+            tessellator.setNormal(1.0F, 0.0F, 0.0F);
+            this.renderFaceXPos(block, epsilon, 0.0D, 0.0D, BlockGrass.getIconSideOverlay());
+            tessellator.draw();
+
+            GL11.glColor4f(p_147800_3_, p_147800_3_, p_147800_3_, 1.0F);
+            GL11.glTranslatef(0.5F, 0.5F, 0.5F);
+        }
+    }
+}


### PR DESCRIPTION
This PR backports the change from Minecraft 1.8+ where grass blocks in the inventory now have their sides colored instead of rendering with the default fast texture. For consistency with terrain rendering, this only applies if the `fancyGrass` flag is set in `RenderBlocks` (i.e. user is using Fancy graphics, or another mod is overriding it to true).

Players who prefer the old look can disable this in the config.