### PR TITLE
Add altered versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,3 +3,25 @@
 plugins {
     id 'com.gtnewhorizons.gtnhconvention'
 }
+
+// The planned name of the next release
+def NEXT_VERSION = "2.6.1"
+version = NEXT_VERSION
+
+// Append to the version as needed. If the variables look a bit strange, that's because they are -
+// git-version doesn't expose a ton of useful functions, we need to extract them indirectly.
+
+// If we have a clean tag (or manually specified), this is a production release.
+// No need for the commit hash!
+def details = versionDetails()
+def isPlainTag = details.getCommitDistance() == 0
+def noCommitHash = providers.gradleProperty("noCommitHash").isPresent()
+if (!isPlainTag && !noCommitHash) {
+    version += "-" + details.gitHash
+}
+
+// If we have uncommitted changes, say so.
+def isDirty = gitVersion().endsWith(".dirty")
+if (isDirty && !noCommitHash) {
+    version += "-dirty"
+}


### PR DESCRIPTION
There are 3 cases:
- `-PnoCommitHash` is passed. This results in `VERSION=LATEST_VERSION` always.
- There is a tag on this commit. This results in `VERSION=LATEST_VERSION`, with `-dirty` appended if there is uncommitted work.
- Otherwise, you get `VERSION=LATEST_VERSION-<hash>`, with `-dirty` appended if there is uncommitted work.