### PR TITLE
Un vertically challenged🛫🛫🛫🛫🛫🛫🛫

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigMixins.java
@@ -84,7 +84,7 @@ public class ConfigMixins extends ConfigBase {
 		enableNewElytraTakeoffLogic = getBoolean("enableNewElytraTakeoffLogic", catBackport, true, "When enabled, the 1.15+ elytra takeoff logic is used, when disabled, the 1.9-1.14 elytra takeoff logic is used.");
 		enableDoWeatherCycle = getBoolean("enableDoWeatherCycle", catBackport, true, "Add the doWeatherCycle game rule from 1.11+");
 		enableRandomTickSpeed = getBoolean("enableRandomTickSpeed", catBackport, true, "Add the randomTickSpeed game rule from 1.8+");
-		creativeFlightSpeedModifier = getFloat("creativeFlightSpeedModifier", catBackport, 2, 1, 4, "When greater than 1, boosts creative flight speed when sprinting, like in newer versions");
+		creativeFlightSpeedModifier = getFloat("creativeFlightSpeedModifier", catBackport, 2, 1, 5, "When greater than 1, boosts creative flight speed when sprinting, like in newer versions");
 		bouncyBeds = getBoolean("bouncyBeds", catBackport, true, "Makes beds bouncy. Should work with most modded beds. For continuity disabling this also disables EFR beds being bouncy.\nModified Classes: net.minecraft.block.BlockBed");
 		floorCeilingButtons = getBoolean("floorCeilingButtons", catBackport, true, "Allows ability to place buttons on the floor and ceiling. Note: Due to metadata limits, they won't rotate to face the player like how they were made to in more modern versions.\nModified Classes: net.minecraft.block.BlockButton");
 		newHurtSounds = getBoolean("newHurtSounds", catBackport, true, "Damage sounds for walking into a berry bush, drowning or burning\nModified Classes: net.minecraft.entity.player.EntityPlayer net.minecraft.client.entity.EntityClientPlayerMP");

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigTweaks.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigTweaks.java
@@ -16,6 +16,7 @@ public class ConfigTweaks extends ConfigBase {
 	public static boolean deepslateReplacesCobblestone;
 	public static boolean stonecutterSawHurts;
 	public static boolean squidsBlindPlayers;
+	public static float creativeFlightVerticalModifier;
 
 	public static final String catAbandoned = "abandoned ideas";
 	public static final String catCustomTweaks = "custom tweaks";
@@ -43,6 +44,7 @@ public class ConfigTweaks extends ConfigBase {
 		deepslateReplacesCobblestone = getBoolean("deepslateReplacesCobblestone", catCustomTweaks, false, "If you want cobblestone to be replaced with cobbled deepslate during world generation.");
 		stonecutterSawHurts = getBoolean("stonecutterSawHurts", catCustomTweaks, false, "If you want stonecutters to deal damage to players standing on them.");
 		squidsBlindPlayers = getBoolean("squidsBlindPlayers", catCustomTweaks, false, "Squids will blind players when they take damage.");
+		creativeFlightVerticalModifier = getFloat("creativeFlightVerticalModifier", catCustomTweaks, 1, 1, 5, "When greater than 1, boosts vertical(up/down) creative flight speed when sprinting.");
 	}
 
 }

--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
@@ -9,6 +9,7 @@ import ganymedes01.etfuturum.configuration.ConfigBase;
 import ganymedes01.etfuturum.configuration.configs.ConfigEnchantsPotions;
 import ganymedes01.etfuturum.configuration.configs.ConfigEntities;
 import ganymedes01.etfuturum.configuration.configs.ConfigMixins;
+import ganymedes01.etfuturum.configuration.configs.ConfigTweaks;
 import ganymedes01.etfuturum.lib.Reference;
 import net.minecraft.launchwrapper.Launch;
 import org.spongepowered.asm.mixin.MixinEnvironment;
@@ -129,7 +130,7 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 			mixins.add("randomtickspeed.MixinWorldServer");
 		}
 
-		if (ConfigMixins.creativeFlightSpeedModifier > 1) {
+		if (ConfigMixins.creativeFlightSpeedModifier > 1 || ConfigTweaks.creativeFlightVerticalModifier > 1) {
 			mixins.add("flyspeed.MixinEntityPlayer");
 		}
 

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/flyspeed/MixinEntityPlayer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/flyspeed/MixinEntityPlayer.java
@@ -1,6 +1,7 @@
 package ganymedes01.etfuturum.mixins.early.flyspeed;
 
 import ganymedes01.etfuturum.configuration.configs.ConfigMixins;
+import ganymedes01.etfuturum.configuration.configs.ConfigTweaks;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.PlayerCapabilities;
@@ -23,5 +24,6 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
 	@Inject(method = "moveEntityWithHeading", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/EntityLivingBase;moveEntityWithHeading(FF)V", ordinal = 0))
 	private void setMovementFactor(float p_70612_1_, float p_70612_2_, CallbackInfo ci) {
 		this.jumpMovementFactor = this.capabilities.getFlySpeed() * (this.isSprinting() ? ConfigMixins.creativeFlightSpeedModifier : 1);
+		this.motionY = this.motionY * 0.6D * (this.isSprinting() ? ConfigTweaks.creativeFlightVerticalModifier : 1);
 	}
 }


### PR DESCRIPTION
Adds a new config option to tweak vertical creative
flight speed _while sprinting_. This is disabled by
default and found in tweaks.cfg rather than mixins.cfg
for being non-vanilla behavior.

In vanilla, vertical flight is 3/5 the speed of horizontal
flight, so users who want a 1:1 x/y flight speed ratio can
set verticalFlightSpeed higher than its horizontal
counterpart.

There is one, problem, with this currently, and that is
the flight down button (shift) also stops the player from
sprinting. I plan to address this in another PR/commit
that prevents shift from breaking sprint in creative.
( will be disabled by default )

Also has a commit changing the config flight speed limit
from 4 to 5 because 4 is too slow for me