### PR TITLE
Fix inverted collision check when not in spectactor mode

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/mixins/early/spectator/MixinEntityPlayer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/spectator/MixinEntityPlayer.java
@@ -36,7 +36,7 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
 
 	@Override
 	public boolean canBeCollidedWith() {
-		return !SpectatorMode.isSpectator((EntityPlayer) (Object) this) && !super.canBeCollidedWith();
+		return !SpectatorMode.isSpectator((EntityPlayer) (Object) this) && super.canBeCollidedWith();
 	}
 
 	@Override


### PR DESCRIPTION
Added in https://github.com/Roadhog360/Et-Futurum-Requiem/commit/d4eb32640b60f8d7f01c097d6ff69402f525856c