### PR TITLE
Fix players PvP

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/mixins/early/spectator/MixinEntityPlayer.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/spectator/MixinEntityPlayer.java
@@ -89,10 +89,4 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
 			}
 		}
 	}
-
-	@Override
-	public boolean canAttackWithItem()
-	{
-		return false;
-	}
 }


### PR DESCRIPTION
Removes wrongly added canAttackWithItem from MixinEntityPlayer, so players can attach each others