### PR TITLE
Cache randomTickSpeed to reduce unnecessary lookups

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/EtFuturum.java
+++ b/src/main/java/ganymedes01/etfuturum/EtFuturum.java
@@ -155,7 +155,7 @@ public class EtFuturum {
 	@EventHandler
 	public void onConstruction(FMLConstructionEvent event) {
 		if(Reference.SNAPSHOT_BUILD && !Reference.DEV_ENVIRONMENT) {
-			Logger.info(Reference.MOD_ID + " is in snapshot mode. Disabling update checker... Other features may also be different.");
+			Logger.info(Tags.MOD_ID + " is in snapshot mode. Disabling update checker... Other features may also be different.");
 		}
 
 		MCLib.init();

--- a/src/main/java/ganymedes01/etfuturum/gamerule/RandomTickSpeed.java
+++ b/src/main/java/ganymedes01/etfuturum/gamerule/RandomTickSpeed.java
@@ -10,10 +10,10 @@ public class RandomTickSpeed {
 
 	public static final String GAMERULE_NAME = "randomTickSpeed";
 	public static final String DEFAULT_VALUE = "3";
-	public Integer CURRENT_VALUE = null;
+	public int CURRENT_VALUE = -1;
 
 	public int getRandomTickSpeed(GameRules gameRulesInstance) {
-		if (RandomTickSpeed.INSTANCE.CURRENT_VALUE == null) {
+		if (RandomTickSpeed.INSTANCE.CURRENT_VALUE == -1) {
 			RandomTickSpeed.INSTANCE.CURRENT_VALUE = Integer.parseInt(StringUtils.defaultIfEmpty(gameRulesInstance.getGameRuleStringValue(GAMERULE_NAME), DEFAULT_VALUE));
 		}
 		return RandomTickSpeed.INSTANCE.CURRENT_VALUE;

--- a/src/main/java/ganymedes01/etfuturum/gamerule/RandomTickSpeed.java
+++ b/src/main/java/ganymedes01/etfuturum/gamerule/RandomTickSpeed.java
@@ -10,9 +10,13 @@ public class RandomTickSpeed {
 
 	public static final String GAMERULE_NAME = "randomTickSpeed";
 	public static final String DEFAULT_VALUE = "3";
+	public Integer CURRENT_VALUE = null;
 
 	public int getRandomTickSpeed(GameRules gameRulesInstance) {
-		return Integer.parseInt(StringUtils.defaultIfEmpty(gameRulesInstance.getGameRuleStringValue(GAMERULE_NAME), DEFAULT_VALUE));
+		if (RandomTickSpeed.INSTANCE.CURRENT_VALUE == null) {
+			RandomTickSpeed.INSTANCE.CURRENT_VALUE = Integer.parseInt(StringUtils.defaultIfEmpty(gameRulesInstance.getGameRuleStringValue(GAMERULE_NAME), DEFAULT_VALUE));
+		}
+		return RandomTickSpeed.INSTANCE.CURRENT_VALUE;
 	}
 
 	public static void registerGamerule(World world) {

--- a/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
+++ b/src/main/java/ganymedes01/etfuturum/mixinplugin/EtFuturumEarlyMixins.java
@@ -128,6 +128,7 @@ public class EtFuturumEarlyMixins implements IFMLLoadingPlugin, IEarlyMixinLoade
 
 		if (ConfigMixins.enableRandomTickSpeed) {
 			mixins.add("randomtickspeed.MixinWorldServer");
+			mixins.add("randomtickspeed.MixinGameRules");
 		}
 
 		if (ConfigMixins.creativeFlightSpeedModifier > 1 || ConfigTweaks.creativeFlightVerticalModifier > 1) {

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/randomtickspeed/MixinGameRules.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/randomtickspeed/MixinGameRules.java
@@ -1,0 +1,20 @@
+package ganymedes01.etfuturum.mixins.early.randomtickspeed;
+
+import ganymedes01.etfuturum.gamerule.RandomTickSpeed;
+import net.minecraft.world.GameRules;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+
+@Mixin(GameRules.class)
+public class MixinGameRules {
+    @Inject(method = "setOrCreateGameRule", at = @At("RETURN"))
+    private void onGameRuleChanged(String ruleName, String value, CallbackInfo ci) {
+        // Your code here to handle gamerule changes
+        if (ruleName.equals("randomTickSpeed")) {
+            RandomTickSpeed.INSTANCE.CURRENT_VALUE = null;
+        }
+    }
+}

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/randomtickspeed/MixinGameRules.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/randomtickspeed/MixinGameRules.java
@@ -14,7 +14,7 @@ public class MixinGameRules {
     private void onGameRuleChanged(String ruleName, String value, CallbackInfo ci) {
         // Your code here to handle gamerule changes
         if (ruleName.equals("randomTickSpeed")) {
-            RandomTickSpeed.INSTANCE.CURRENT_VALUE = null;
+            RandomTickSpeed.INSTANCE.CURRENT_VALUE = -1;
         }
     }
 }

--- a/src/main/java/ganymedes01/etfuturum/mixins/early/randomtickspeed/MixinGameRules.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/randomtickspeed/MixinGameRules.java
@@ -1,6 +1,7 @@
 package ganymedes01.etfuturum.mixins.early.randomtickspeed;
 
 import ganymedes01.etfuturum.gamerule.RandomTickSpeed;
+import org.apache.commons.lang3.StringUtils;
 import net.minecraft.world.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -14,7 +15,7 @@ public class MixinGameRules {
     private void onGameRuleChanged(String ruleName, String value, CallbackInfo ci) {
         // Your code here to handle gamerule changes
         if (ruleName.equals("randomTickSpeed")) {
-            RandomTickSpeed.INSTANCE.CURRENT_VALUE = -1;
+            RandomTickSpeed.INSTANCE.CURRENT_VALUE = Integer.parseInt(StringUtils.defaultIfEmpty(value, RandomTickSpeed.DEFAULT_VALUE));
         }
     }
 }


### PR DESCRIPTION
This PR caches the costly lookup of randomTickSpeed, to improve performance.

I had to change out the log call trying to reference a mod id via "Reference" which did not seem to contain MOD_ID with "Tags", please correct me if im wrong on that.
