### PR TITLE
Update localization key for armor stand

### DIFF
--- a/src/main/resources/assets/etfuturum/lang/de_DE.lang
+++ b/src/main/resources/assets/etfuturum/lang/de_DE.lang
@@ -275,7 +275,7 @@ subtitle.ambient.weather.thunder=Donner grollt
 
 # Objekte
 entity.etfuturum.endermite.name=Endermite
-entity.etfuturum.armor_stand.name=Rüstungsständer
+entity.etfuturum.wooden_armorstand.name=Rüstungsständer
 entity.etfuturum.rabbit.name=Kaninchen
 entity.etfuturum.villager_zombie.name=Zombiedorfbewohner
 entity.etfuturum.end_crystal.name=Enderkristall

--- a/src/main/resources/assets/etfuturum/lang/en_GB.lang
+++ b/src/main/resources/assets/etfuturum/lang/en_GB.lang
@@ -7,7 +7,7 @@ subtitle.item.armor.equip_diamond=Diamond armour equipped
 subtitle.item.armor.equip_netherite=Netherite armour equipped
 
 # Entities
-entity.etfuturum.armor_stand.name=Armour Stand
+entity.etfuturum.wooden_armorstand.name=Armour Stand
 
 # Items
 item.etfuturum.armor_stand.name=Armour Stand

--- a/src/main/resources/assets/etfuturum/lang/en_US.lang
+++ b/src/main/resources/assets/etfuturum/lang/en_US.lang
@@ -314,7 +314,7 @@ subtitle.ambient.weather.thunder=Thunder strikes
 
 # Entities
 entity.etfuturum.endermite.name=Endermite
-entity.etfuturum.armor_stand.name=Armor Stand
+entity.etfuturum.wooden_armorstand.name=Armor Stand
 entity.etfuturum.rabbit.name=Rabbit
 entity.etfuturum.villager_zombie.name=Villager Zombie
 entity.etfuturum.end_crystal.name=End Crystal

--- a/src/main/resources/assets/etfuturum/lang/ru_RU.lang
+++ b/src/main/resources/assets/etfuturum/lang/ru_RU.lang
@@ -273,7 +273,7 @@ subtitle.ambient.weather.thunder=Гром
 
 # Сущности (Entities)
 entity.etfuturum.endermite.name=Чешуйница Края
-entity.etfuturum.armor_stand.name=Стойка для брони
+entity.etfuturum.wooden_armorstand.name=Стойка для брони
 entity.etfuturum.rabbit.name=Кролик
 entity.etfuturum.villager_zombie.name=Зомби-житель
 entity.etfuturum.end_crystal.name=Кристалл Края

--- a/src/main/resources/assets/etfuturum/lang/zh_CN.lang
+++ b/src/main/resources/assets/etfuturum/lang/zh_CN.lang
@@ -273,7 +273,7 @@ subtitle.ambient.weather.thunder=电闪雷鸣
 
 # Entities
 entity.etfuturum.endermite.name=末影螨
-entity.etfuturum.armor_stand.name=盔甲架
+entity.etfuturum.wooden_armorstand.name=盔甲架
 entity.etfuturum.rabbit.name=兔子
 entity.etfuturum.villager_zombie.name=僵尸村民
 entity.etfuturum.end_crystal.name=末地水晶


### PR DESCRIPTION
Fixes #620 , looks like armor stand was renamed to wooden_armorstand at some point the localization was left behind, this PR fixes that.

Now looks like: 
![Screenshot_391](https://github.com/user-attachments/assets/2fe4de49-1448-43e7-8103-564554d8d98f)