### PR TITLE
Rework item lava floating physics, fix #616

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/mixins/early/uninflammableitem/MixinEntityItem.java
+++ b/src/main/java/ganymedes01/etfuturum/mixins/early/uninflammableitem/MixinEntityItem.java
@@ -40,9 +40,6 @@ public abstract class MixinEntityItem extends Entity {
 					|| tags.contains("ingotNetherite") || tags.contains("blockNetherite")) {
 				this.isImmuneToFire = true;
 				this.fireResistance = Integer.MAX_VALUE;
-			} else if (isImmuneToFire) {
-				this.isImmuneToFire = false;
-				this.fireResistance = 1;
 			}
 		}
 	}


### PR DESCRIPTION
This PR mostly fixes the strong bounding  of items when floating on lava between client and server, along with removing the sliding of items.

Example:
- Before

https://github.com/user-attachments/assets/bcb40f3e-01d6-46b8-afee-e82da1efd69e


- After


https://github.com/user-attachments/assets/bfb744f0-5385-4a3c-bb40-3fc6b70e4e74


Note: I saw the todo for converting the floatLava mixin to a WrapOperation, but I'm sure where I would place that - maybe now its easier.