### PR TITLE
Added the ability for usages to show up when pressing 'U' on the smoker and blast furnace.

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/compat/nei/BlastFurnaceRecipeHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/compat/nei/BlastFurnaceRecipeHandler.java
@@ -2,11 +2,13 @@ package ganymedes01.etfuturum.compat.nei;
 
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.recipe.FurnaceRecipeHandler;
+import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.client.gui.inventory.GuiBlastFurnace;
 import ganymedes01.etfuturum.core.utils.ItemStackMap;
 import ganymedes01.etfuturum.recipes.BlastFurnaceRecipes;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 
@@ -80,6 +82,11 @@ public class BlastFurnaceRecipeHandler extends FurnaceRecipeHandler {
 
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
+		if (ingredient != null && ingredient.getItem() == Item.getItemFromBlock(ModBlocks.BLAST_FURNACE.get()))
+		{
+			loadCraftingRecipes(getOverlayIdentifier());
+			return;
+		}
 		if (usagecache.isEmpty()) {
 			Map<ItemStack, ItemStack> furnaceSmeltingList = FurnaceRecipes.smelting().getSmeltingList();
 			ItemStackMap<ItemStack> recipes = new ItemStackMap<>();

--- a/src/main/java/ganymedes01/etfuturum/compat/nei/SmokerRecipeHandler.java
+++ b/src/main/java/ganymedes01/etfuturum/compat/nei/SmokerRecipeHandler.java
@@ -2,10 +2,12 @@ package ganymedes01.etfuturum.compat.nei;
 
 import codechicken.nei.NEIServerUtils;
 import codechicken.nei.recipe.FurnaceRecipeHandler;
+import ganymedes01.etfuturum.ModBlocks;
 import ganymedes01.etfuturum.client.gui.inventory.GuiSmoker;
 import ganymedes01.etfuturum.core.utils.ItemStackMap;
 import ganymedes01.etfuturum.recipes.SmokerRecipes;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.util.StatCollector;
@@ -81,6 +83,11 @@ public class SmokerRecipeHandler extends FurnaceRecipeHandler {
 
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
+		if (ingredient != null && ingredient.getItem() == Item.getItemFromBlock(ModBlocks.SMOKER.get()))
+		{
+			loadCraftingRecipes(getOverlayIdentifier());
+			return;
+		}
 		if (usagecache.isEmpty()) {
 			Map<ItemStack, ItemStack> furnaceSmeltingList = FurnaceRecipes.smelting().getSmeltingList();
 			ItemStackMap<ItemStack> recipes = new ItemStackMap<>();


### PR DESCRIPTION
Just what the title says. Added a short tidbit to the loadUsageRecipes at the beginning to check if the item stack is the block itself. I think it worked well enough. Needs testing in a larger modpack, but I can't do that tonight. Will return tomorrow with more results during testing, but it seems to work right now.

Came from my question in the legacy modding discord [here](https://discord.com/channels/741043720241152001/899390796732715068/1393036236360384602)

I don't know if it'll work with MT recipes or auto-added recipes, I imagine it will, but just in case. I wouldn't merge this until it's confirmed by either me or a reviewer.