### PR TITLE
NetherOres support for rawOres

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/api/RawOreRegistry.java
+++ b/src/main/java/ganymedes01/etfuturum/api/RawOreRegistry.java
@@ -2,6 +2,7 @@ package ganymedes01.etfuturum.api;
 
 import ganymedes01.etfuturum.ModItems;
 import ganymedes01.etfuturum.api.mappings.RawOreDropMapping;
+import ganymedes01.etfuturum.compat.ModsList;
 import ganymedes01.etfuturum.configuration.configs.ConfigBlocksItems;
 import ganymedes01.etfuturum.configuration.configs.ConfigFunctions;
 import ganymedes01.etfuturum.core.utils.Utils;
@@ -49,7 +50,7 @@ public class RawOreRegistry {
 	public static void addOre(String oreDict, Item ore, int meta) {
 		if (RecipeHelper.validateItems(ore)) {
 			RawOreDropMapping mapping = new RawOreDropMapping(ore, meta);
-			if (ArrayUtils.contains(ConfigFunctions.extraDropRawOres, oreDict)) {
+			if (ArrayUtils.contains(ConfigFunctions.extraDropRawOres, oreDict.replace("oreNether", "ore"))) {
 				mapping.setDropsExtra(true);
 			}
 			addOre(oreDict, mapping);
@@ -103,9 +104,15 @@ public class RawOreRegistry {
 		if (ModItems.RAW_ORE.isEnabled()) {
 			if (ConfigBlocksItems.enableCopper || OreDictionary.doesOreNameExist("ingotCopper")) {
 				addOre("oreCopper", ModItems.RAW_ORE.get());
+				if(ModsList.NETHERORES.isLoaded())
+					addOre("oreNetherCopper", ModItems.RAW_ORE.get());
 			}
 			addOre("oreIron", ModItems.RAW_ORE.get(), 1);
 			addOre("oreGold", ModItems.RAW_ORE.get(), 2);
+			if(ModsList.NETHERORES.isLoaded()) {
+				addOre("oreNetherIron", ModItems.RAW_ORE.get(), 1);
+				addOre("oreNetherGold", ModItems.RAW_ORE.get(), 2);
+			}
 		}
 		if (Utils.enableModdedRawOres()) {
 			for (ItemGeneralModdedRawOre oreItem : ItemGeneralModdedRawOre.loaded) {
@@ -114,6 +121,9 @@ public class RawOreRegistry {
 					for (int j = 0; j < 1; j++) {
 						if (Utils.listGeneralModdedRawOre(type.replace("ingot", "ore"))) { //If it's mythril, we'll run this once more, changing the spelling to mithril to account for both tags.
 							addOre(type.replace("ingot", "ore"), ModItems.MODDED_RAW_ORE.get(), i);
+							if(ModsList.NETHERORES.isLoaded()) {
+								addOre(type.replace("ingot", "oreNether"), ModItems.MODDED_RAW_ORE.get(), i);
+							}
 						}
 						if (type.endsWith("Mythril")) {
 							type = type.replace("Mythril", "Mithril"); //Redoes it once more for mithril spelling

--- a/src/main/java/ganymedes01/etfuturum/api/RawOreRegistry.java
+++ b/src/main/java/ganymedes01/etfuturum/api/RawOreRegistry.java
@@ -119,7 +119,7 @@ public class RawOreRegistry {
 				for (int i = 0; i < oreItem.ores.length; i++) {
 					String type = oreItem.ores[i];
 					for (int j = 0; j < 1; j++) {
-						if (Utils.listGeneralModdedRawOre(type.replace("ingot", "ore"))) { //If it's mythril, we'll run this once more, changing the spelling to mithril to account for both tags.
+						if (Utils.listGeneralModdedRawOre(type)) { //If it's mythril, we'll run this once more, changing the spelling to mithril to account for both tags.
 							addOre(type.replace("ingot", "ore"), ModItems.MODDED_RAW_ORE.get(), i);
 							if(ModsList.NETHERORES.isLoaded()) {
 								addOre(type.replace("ingot", "oreNether"), ModItems.MODDED_RAW_ORE.get(), i);

--- a/src/main/java/ganymedes01/etfuturum/compat/ModsList.java
+++ b/src/main/java/ganymedes01/etfuturum/compat/ModsList.java
@@ -38,6 +38,7 @@ public enum ModsList {
 	BIG_REACTORS("BigReactors"),
 	FISKS_SUPERHEROES("fiskheroes"),
 	SIMPLEORES("simpleores"),
+	NETHERORES("NetherOres"),
 	DRAGON_QUEST("DQMIIINext"),
 	LOTR("lotr"),
 


### PR DESCRIPTION
## Tested with IC2 and the latest CurseForge release version of Nether Ores: 2.3.1-22

# Functionality:
- When registering vanilla/ EFR ores, it checks for NetherOres in the mods list and adds the oredict tag to the drops
- When finding a modded instance of a raw ore (i.e. IC2 tin) it checks for NetherOres in the mods list and adds the oredict tag to the drops along with the non-Nether tag, as it used to.

Also removed a redundant call to the replace method since it was already done. Didn't have any adverse effects (I mean, it shouldn't anyway, but I had to make sure). 

That commit can be undone if you had an actual reason (I didn't see any)