### PR TITLE
Allow Mending to work on items in Baubles slots

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/ModEnchantments.java
+++ b/src/main/java/ganymedes01/etfuturum/ModEnchantments.java
@@ -1,6 +1,9 @@
 package ganymedes01.etfuturum;
 
+import baubles.common.lib.PlayerHandler;
+import ganymedes01.etfuturum.compat.ModsList;
 import ganymedes01.etfuturum.configuration.configs.ConfigEnchantsPotions;
+import ganymedes01.etfuturum.configuration.configs.ConfigModCompat;
 import ganymedes01.etfuturum.enchantment.FrostWalker;
 import ganymedes01.etfuturum.enchantment.Mending;
 import ganymedes01.etfuturum.enchantment.SwiftSneak;
@@ -17,6 +20,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.event.entity.player.PlayerPickupXpEvent;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -84,12 +89,18 @@ public class ModEnchantments {
 		if (!ConfigEnchantsPotions.enableMending)
 			return;
 
-		ItemStack[] stacks = new ItemStack[5];
-		stacks[0] = player.getCurrentEquippedItem(); // held
-		stacks[1] = player.getEquipmentInSlot(1); // boots
-		stacks[2] = player.getEquipmentInSlot(2); // leggings
-		stacks[3] = player.getEquipmentInSlot(3); // chestplate
-		stacks[4] = player.getEquipmentInSlot(4); // helmet
+		ArrayList<ItemStack> stacks = new ArrayList<>();
+		stacks.add(player.getCurrentEquippedItem()); // held
+		stacks.add(player.getEquipmentInSlot(1)); // boots
+		stacks.add(player.getEquipmentInSlot(2)); // leggings
+		stacks.add(player.getEquipmentInSlot(3)); // chestplate
+		stacks.add(player.getEquipmentInSlot(4)); // helmet
+		if (ModsList.BAUBLES.isLoaded() && ConfigModCompat.baublesMending) {
+			ItemStack[] baubles = PlayerHandler.getPlayerBaubles(player).stackList;
+			if (baubles != null) {
+				Collections.addAll(stacks, baubles);
+			}
+		}
 
 		for (ItemStack stack : stacks)
 			if (stack != null && stack.getItemDamage() > 0 && EnchantmentHelper.getEnchantmentLevel(mending.effectId, stack) > 0) {

--- a/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigModCompat.java
+++ b/src/main/java/ganymedes01/etfuturum/configuration/configs/ConfigModCompat.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class ConfigModCompat extends ConfigBase {
 
 	public static int elytraBaublesExpandedCompat;
+	public static boolean baublesMending;
 	public static boolean shulkerBoxesIronChest;
 
 	public static boolean moddedRawOres;
@@ -49,6 +50,7 @@ public class ConfigModCompat extends ConfigBase {
 				0 = No compat, do not allow the elytra to be placed in a wings slot.\
 				1 = Elytra will be placeable in a wings slot. Will enable the slot, if it isn't there.\
 				2 = The elytra can ONLY go in the wings slots, not the chestplate slot.""");
+		baublesMending = getBoolean("baublesMending", catMisc, true, "If Baubles (or Baubles Expanded) is installed, allows the Mending enchantment to repair items that are worn in bauble slots when experience is collected.\nThis option does nothing if Baubles (or BE) is not installed or if the Mending enchantment is disabled.");
 		soulFireColor = (short) getInt("soulFireColor", catRPLE, 0x49A, 0x000, 0xFFF, """
 						The color of soul fire. Needs to be a separate option because it's a mixin for fire and not a meta state.
 						Does not have any effect on the color of soul lanterns or soul torches. Check the RPLE colors config for those.""");


### PR DESCRIPTION
Mending works with items in Curios (the modern equivalent to Baubles) slots. This makes it work with Baubles!

Example video:

https://github.com/user-attachments/assets/889db65f-d408-4cfd-8cb9-ebdda902a678

There is also a config to disable this functionality.