### PR TITLE
Fix crash when placing renamed Blast Furnace

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBlastFurnace.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntityBlastFurnace.java
@@ -32,7 +32,6 @@ public class TileEntityBlastFurnace extends TileEntityFurnace implements ISidedI
 	 * The number of ticks that the current item has been cooking for
 	 */
 	public int furnaceCookTime;
-	private String furnaceCustomName;
 
 	/**
 	 * Returns the number of slots in the inventory.
@@ -106,19 +105,7 @@ public class TileEntityBlastFurnace extends TileEntityFurnace implements ISidedI
 	 */
 	@Override
 	public String getInventoryName() {
-		return this.hasCustomInventoryName() ? this.furnaceCustomName : "container." + Tags.MOD_ID + ".blast_furnace";
-	}
-
-	/**
-	 * Returns if the inventory is named
-	 */
-	@Override
-	public boolean hasCustomInventoryName() {
-		return this.furnaceCustomName != null && this.furnaceCustomName.length() > 0;
-	}
-
-	public void func_145951_a(String p_145951_1_) {
-		this.furnaceCustomName = p_145951_1_;
+		return this.hasCustomInventoryName() ? this.field_145958_o : "container." + Tags.MOD_ID + ".blast_furnace";
 	}
 
 	@Override
@@ -133,7 +120,7 @@ public class TileEntityBlastFurnace extends TileEntityFurnace implements ISidedI
 		this.currentItemBurnTime = getItemBurnTime(this.furnaceItemStacks[1]);
 
 		if (compound.hasKey("CustomName", 8)) {
-			this.furnaceCustomName = compound.getString("CustomName");
+			this.field_145958_o = compound.getString("CustomName");
 		}
 	}
 
@@ -146,7 +133,7 @@ public class TileEntityBlastFurnace extends TileEntityFurnace implements ISidedI
 		compound.setTag("Items", Utils.writeItemStacksToNBT(this.furnaceItemStacks));
 
 		if (this.hasCustomInventoryName()) {
-			compound.setString("CustomName", this.furnaceCustomName);
+			compound.setString("CustomName", this.field_145958_o);
 		}
 	}
 

--- a/src/main/java/ganymedes01/etfuturum/tileentities/TileEntitySmoker.java
+++ b/src/main/java/ganymedes01/etfuturum/tileentities/TileEntitySmoker.java
@@ -36,7 +36,6 @@ public class TileEntitySmoker extends TileEntityFurnace implements ISidedInvento
 	 * The number of ticks that the current item has been cooking for
 	 */
 	public int furnaceCookTime;
-	private String furnaceCustomName;
 
 	/**
 	 * Returns the number of slots in the inventory.
@@ -110,19 +109,7 @@ public class TileEntitySmoker extends TileEntityFurnace implements ISidedInvento
 	 */
 	@Override
 	public String getInventoryName() {
-		return this.hasCustomInventoryName() ? this.furnaceCustomName : "container." + Tags.MOD_ID + ".smoker";
-	}
-
-	/**
-	 * Returns if the inventory is named
-	 */
-	@Override
-	public boolean hasCustomInventoryName() {
-		return this.furnaceCustomName != null && this.furnaceCustomName.length() > 0;
-	}
-
-	public void func_145951_a(String p_145951_1_) {
-		this.furnaceCustomName = p_145951_1_;
+		return this.hasCustomInventoryName() ? this.field_145958_o : "container." + Tags.MOD_ID + ".smoker";
 	}
 
 	@Override
@@ -137,7 +124,7 @@ public class TileEntitySmoker extends TileEntityFurnace implements ISidedInvento
 		this.currentItemBurnTime = getItemBurnTime(this.furnaceItemStacks[1]);
 
 		if (compound.hasKey("CustomName", 8)) {
-			this.furnaceCustomName = compound.getString("CustomName");
+			this.field_145958_o = compound.getString("CustomName");
 		}
 	}
 
@@ -150,7 +137,7 @@ public class TileEntitySmoker extends TileEntityFurnace implements ISidedInvento
 		compound.setTag("Items", Utils.writeItemStacksToNBT(this.furnaceItemStacks));
 
 		if (this.hasCustomInventoryName()) {
-			compound.setString("CustomName", this.furnaceCustomName);
+			compound.setString("CustomName", this.field_145958_o);
 		}
 	}
 

--- a/src/main/resources/META-INF/etfuturum_at.cfg
+++ b/src/main/resources/META-INF/etfuturum_at.cfg
@@ -95,6 +95,12 @@ protected net.minecraft.pathfinding.PathNavigate field_75515_a #theEntity
 protected net.minecraft.pathfinding.PathNavigate field_75511_d #speed
 
 #================================#
+#==========TILEENTITIES==========#
+#================================#
+
+protected net.minecraft.tileentity.TileEntityFurnace field_145958_o
+
+#================================#
 #==============MISC==============#
 #================================#
 public net.minecraft.client.resources.SimpleResource field_110530_g #mcmetaJson


### PR DESCRIPTION
Renaming a Blast Furnace in an Anvil and placing it results in a crash.

This happens, because when placing the Blast Furnace, `BlockFurnace#onBlockPlacedBy` is called which `BlockBlastFurnace` inherits. However, that method expects the corresponding TE to be a `TileEntityFurnace` which is not given for the Blast Furnace as it is not a child class.

This PR makes `TileEntityBlastFurnace` inherit from `TileEntityFurnace`. This seemed like the most straightforward way to implement this to me. However, there might be a reason the TEs didn't inherit from the furnace previously? At least I couldn't find any, but let me know if there is. Alternatively, we could also reimplement `onBlockPlacedBy` in the corresponding Block classes.

The same issue also applies to the Smoker.

A second commit adds some light refactoring based on the newly introduced relationship making some code redundant.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21649