### PR TITLE
add rawOre to blasting recipes compat

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/BlastFurnaceRecipes.java
@@ -100,8 +100,8 @@ public class BlastFurnaceRecipes {
 					if (oreName.startsWith("ore")) {
 						return true;
 					}
-                    // GT Raw Ores
-                    if (oreName.startsWith("rawOre")) {
+                    // Raw Ores
+                    if(oreName.matches("raw[A-Z].*")) {
                         return true;
                     }
 					// Thaumcraft Ore Cluster Items.

--- a/src/main/java/ganymedes01/etfuturum/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/BlastFurnaceRecipes.java
@@ -100,6 +100,10 @@ public class BlastFurnaceRecipes {
 					if (oreName.startsWith("ore")) {
 						return true;
 					}
+                    // GT Raw Ores
+                    if (oreName.startsWith("rawOre")) {
+                        return true;
+                    }
 					// Thaumcraft Ore Cluster Items.
 					if (oreName.startsWith("cluster")) {
 						return true;

--- a/src/main/java/ganymedes01/etfuturum/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/BlastFurnaceRecipes.java
@@ -101,7 +101,7 @@ public class BlastFurnaceRecipes {
 						return true;
 					}
                     // Raw Ores
-                    if(oreName.matches("raw[A-Z].*")) {
+                    if(oreName.matches("^raw[A-Z].*")) {
                         return true;
                     }
 					// Thaumcraft Ore Cluster Items.


### PR DESCRIPTION
this is because gt ores use raw now, for modern reasons i guess. 

tested in dev-env with gt5u implementation, something like "Raw Diamond Ore" now properly works in the blast furnace.
This is parody with Vanilla.