### PR TITLE
Register pickaxe harvest level and OreDictionary name for new stone-type blocks

### DIFF
--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockBasalt.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockBasalt.java
@@ -27,6 +27,7 @@ public class BlockBasalt extends BlockRotatedPillar implements ISubBlocksBlock {
 		setResistance(4.2F);
 		setBlockName(Utils.getUnlocalisedName("basalt"));
 		setBlockTextureName("basalt");
+		setHarvestLevel("pickaxe",0);
 		Utils.setBlockSound(this, ModSounds.soundBasalt);
 		setCreativeTab(EtFuturum.creativeTabBlocks);
 	}

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockBlackstone.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockBlackstone.java
@@ -15,6 +15,7 @@ public class BlockBlackstone extends BaseSubtypesBlock {
 		setResistance(6.0F);
 		setHardness(1.5F);
 		setHardnessValues(2.0F, 1);
+		setHarvestLevel("pickaxe", 0);
 	}
 
 	@Override

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockDeepslate.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockDeepslate.java
@@ -27,6 +27,7 @@ public class BlockDeepslate extends BlockRotatedPillar {
 		this.setBlockName(Utils.getUnlocalisedName("deepslate"));
 		this.setBlockTextureName("deepslate");
 		this.setCreativeTab(EtFuturum.creativeTabBlocks);
+		this.setHarvestLevel("pickaxe", 0);
 		Utils.setBlockSound(this, ModSounds.soundDeepslate);
 	}
 

--- a/src/main/java/ganymedes01/etfuturum/blocks/BlockTuff.java
+++ b/src/main/java/ganymedes01/etfuturum/blocks/BlockTuff.java
@@ -23,6 +23,7 @@ public class BlockTuff extends BaseSubtypesBlock implements IMultiBlockSound {
 		setResistance(6.0F);
 		setNames("tuff");
 		setBlockSound(ModSounds.soundTuff);
+		setHarvestLevel("pickaxe", 0);
 		setCreativeTab(EtFuturum.creativeTabBlocks);
 	}
 

--- a/src/main/java/ganymedes01/etfuturum/recipes/ModTagging.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/ModTagging.java
@@ -389,6 +389,9 @@ public class ModTagging {
 		ItemStack ore10 = ModBlocks.COBBLED_DEEPSLATE.newItemStack();
 		RecipeHelper.registerOre("cobblestone", ore10);
 
+		ItemStack oreDeepslate = ModBlocks.DEEPSLATE.newItemStack();
+		RecipeHelper.registerOre("stone", oreDeepslate);
+
 		RecipeHelper.registerOre("record", ModItems.PIGSTEP_RECORD.get());
 		RecipeHelper.registerOre("record", ModItems.OTHERSIDE_RECORD.get());
 

--- a/src/main/java/ganymedes01/etfuturum/recipes/ModTagging.java
+++ b/src/main/java/ganymedes01/etfuturum/recipes/ModTagging.java
@@ -389,8 +389,14 @@ public class ModTagging {
 		ItemStack ore10 = ModBlocks.COBBLED_DEEPSLATE.newItemStack();
 		RecipeHelper.registerOre("cobblestone", ore10);
 
+		ItemStack oreBasalt = ModBlocks.BASALT.newItemStack();
+		RecipeHelper.registerOre("stone",oreBasalt);
+
 		ItemStack oreDeepslate = ModBlocks.DEEPSLATE.newItemStack();
 		RecipeHelper.registerOre("stone", oreDeepslate);
+
+		ItemStack oreTuff = ModBlocks.TUFF.newItemStack();
+		RecipeHelper.registerOre("stone", oreTuff);
 
 		RecipeHelper.registerOre("record", ModItems.PIGSTEP_RECORD.get());
 		RecipeHelper.registerOre("record", ModItems.OTHERSIDE_RECORD.get());


### PR DESCRIPTION
This PR registers a pickaxe harvest level and OreDictionary name to Basalt, Blackstone(already registered in OreDictionary but not harvest level), Deepslate and Tuff, making it more compatible with some of the checks that other mods use (made so that fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23140).